### PR TITLE
Technical/Refactor consts, configuration

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -9,6 +9,7 @@ type configuration struct {
 	isCmdFailFast                 bool
 	msgGreeting                   string
 	msgInvalidCmd                 string
+	msgQuitCmd                    string
 	msgInvalidCmdHeloSequence     string
 	msgInvalidCmdHeloArg          string
 	msgHeloBlacklistedDomain      string
@@ -17,9 +18,16 @@ type configuration struct {
 	msgInvalidCmdMailfromArg      string
 	msgMailfromBlacklistedEmail   string
 	msgMailfromReceived           string
-	msgQuit                       string
+	msgInvalidCmdRcpttoSequence   string
+	msgInvalidCmdRcpttoArg        string
+	msgRcpttoNotRegistredEmail    string
+	msgRcpttoBlacklistedEmail     string
+	msgRcpttoReceived             string
 	blacklistedHeloDomains        []string
 	blacklistedMailfromEmails     []string
+	registredRcpttoEmails         []string
+	blacklistedRcpttoEmails       []string
+	// TODO: add ability to send 221 response before end of the session
 }
 
 // New configuration builder. Returns pointer to valid new configuration structure
@@ -42,9 +50,16 @@ func NewConfiguration(config ConfigurationAttr) *configuration {
 		msgInvalidCmdMailfromArg:      config.msgInvalidCmdMailfromArg,
 		msgMailfromBlacklistedEmail:   config.msgMailfromBlacklistedEmail,
 		msgMailfromReceived:           config.msgMailfromReceived,
-		msgQuit:                       config.msgQuit,
+		msgInvalidCmdRcpttoSequence:   config.msgInvalidCmdRcpttoSequence,
+		msgInvalidCmdRcpttoArg:        config.msgInvalidCmdRcpttoArg,
+		msgRcpttoNotRegistredEmail:    config.msgRcpttoNotRegistredEmail,
+		msgRcpttoBlacklistedEmail:     config.msgRcpttoBlacklistedEmail,
+		msgRcpttoReceived:             config.msgRcpttoReceived,
+		msgQuitCmd:                    config.msgQuitCmd,
 		blacklistedHeloDomains:        config.blacklistedHeloDomains,
 		blacklistedMailfromEmails:     config.blacklistedMailfromEmails,
+		registredRcpttoEmails:         config.registredRcpttoEmails,
+		blacklistedRcpttoEmails:       config.blacklistedRcpttoEmails,
 	}
 }
 
@@ -57,6 +72,7 @@ type ConfigurationAttr struct {
 	isCmdFailFast                 bool
 	msgGreeting                   string
 	msgInvalidCmd                 string
+	msgQuitCmd                    string
 	msgInvalidCmdHeloSequence     string
 	msgInvalidCmdHeloArg          string
 	msgHeloBlacklistedDomain      string
@@ -65,9 +81,15 @@ type ConfigurationAttr struct {
 	msgInvalidCmdMailfromArg      string
 	msgMailfromBlacklistedEmail   string
 	msgMailfromReceived           string
-	msgQuit                       string
+	msgInvalidCmdRcpttoSequence   string
+	msgInvalidCmdRcpttoArg        string
+	msgRcpttoNotRegistredEmail    string
+	msgRcpttoBlacklistedEmail     string
+	msgRcpttoReceived             string
 	blacklistedHeloDomains        []string
 	blacklistedMailfromEmails     []string
+	registredRcpttoEmails         []string
+	blacklistedRcpttoEmails       []string
 }
 
 // ConfigurationAttr methods
@@ -86,6 +108,11 @@ func (config *ConfigurationAttr) assignDefaultValues() {
 	if config.msgInvalidCmd == EmptyString {
 		config.msgInvalidCmd = DefaultInvalidCmdMsg
 	}
+	if config.msgQuitCmd == EmptyString {
+		config.msgQuitCmd = DefaultQuitMsg
+	}
+
+	// HELO defaults
 	if config.msgInvalidCmdHeloSequence == EmptyString {
 		config.msgInvalidCmdHeloSequence = DefaultInvalidCmdHeloSequenceMsg
 	}
@@ -98,6 +125,8 @@ func (config *ConfigurationAttr) assignDefaultValues() {
 	if config.msgHeloReceived == EmptyString {
 		config.msgHeloReceived = DefaultReceivedMsg
 	}
+
+	// MAIL FROM defaults
 	if config.msgInvalidCmdMailfromSequence == EmptyString {
 		config.msgInvalidCmdMailfromSequence = DefaultInvalidCmdMailfromSequenceMsg
 	}
@@ -110,7 +139,21 @@ func (config *ConfigurationAttr) assignDefaultValues() {
 	if config.msgMailfromReceived == EmptyString {
 		config.msgMailfromReceived = DefaultReceivedMsg
 	}
-	if config.msgQuit == EmptyString {
-		config.msgQuit = DefaultQuitMsg
+
+	// RCPT TO defaults
+	if config.msgInvalidCmdRcpttoSequence == EmptyString {
+		config.msgInvalidCmdRcpttoSequence = DefaultInvalidCmdRcpttoSequenceMsg
+	}
+	if config.msgInvalidCmdRcpttoArg == EmptyString {
+		config.msgInvalidCmdRcpttoArg = DefaultInvalidCmdRcpttoArgMsg
+	}
+	if config.msgRcpttoNotRegistredEmail == EmptyString {
+		config.msgRcpttoNotRegistredEmail = DefaultNotRegistredRcpttoEmailMsg
+	}
+	if config.msgRcpttoBlacklistedEmail == EmptyString {
+		config.msgRcpttoBlacklistedEmail = DefaultQuitMsg
+	}
+	if config.msgRcpttoReceived == EmptyString {
+		config.msgRcpttoReceived = DefaultReceivedMsg
 	}
 }

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -14,17 +14,28 @@ func TestNewConfiguration(t *testing.T) {
 		assert.False(t, buildedConfiguration.isCmdFailFast)
 		assert.Equal(t, DefaultGreetingMsg, buildedConfiguration.msgGreeting)
 		assert.Equal(t, DefaultInvalidCmdMsg, buildedConfiguration.msgInvalidCmd)
+		assert.Equal(t, DefaultQuitMsg, buildedConfiguration.msgQuitCmd)
+
 		assert.Equal(t, DefaultInvalidCmdHeloSequenceMsg, buildedConfiguration.msgInvalidCmdHeloSequence)
 		assert.Equal(t, DefaultInvalidCmdHeloArgMsg, buildedConfiguration.msgInvalidCmdHeloArg)
 		assert.Equal(t, DefaultQuitMsg, buildedConfiguration.msgHeloBlacklistedDomain)
 		assert.Equal(t, DefaultReceivedMsg, buildedConfiguration.msgHeloReceived)
+
 		assert.Equal(t, DefaultInvalidCmdMailfromSequenceMsg, buildedConfiguration.msgInvalidCmdMailfromSequence)
 		assert.Equal(t, DefaultInvalidCmdMailfromArgMsg, buildedConfiguration.msgInvalidCmdMailfromArg)
 		assert.Equal(t, DefaultQuitMsg, buildedConfiguration.msgMailfromBlacklistedEmail)
-		assert.Equal(t, DefaultReceivedMsg, buildedConfiguration.msgHeloReceived)
-		assert.Equal(t, DefaultQuitMsg, buildedConfiguration.msgQuit)
+		assert.Equal(t, DefaultReceivedMsg, buildedConfiguration.msgMailfromReceived)
+
+		assert.Equal(t, DefaultInvalidCmdRcpttoSequenceMsg, buildedConfiguration.msgInvalidCmdRcpttoSequence)
+		assert.Equal(t, DefaultInvalidCmdRcpttoArgMsg, buildedConfiguration.msgInvalidCmdRcpttoArg)
+		assert.Equal(t, DefaultNotRegistredRcpttoEmailMsg, buildedConfiguration.msgRcpttoNotRegistredEmail)
+		assert.Equal(t, DefaultQuitMsg, buildedConfiguration.msgRcpttoBlacklistedEmail)
+		assert.Equal(t, DefaultReceivedMsg, buildedConfiguration.msgRcpttoReceived)
+
 		assert.Empty(t, buildedConfiguration.blacklistedHeloDomains)
 		assert.Empty(t, buildedConfiguration.blacklistedMailfromEmails)
+		assert.Empty(t, buildedConfiguration.registredRcpttoEmails)
+		assert.Empty(t, buildedConfiguration.blacklistedRcpttoEmails)
 	})
 
 	t.Run("creates new configuration with custom settings", func(t *testing.T) {
@@ -33,6 +44,7 @@ func TestNewConfiguration(t *testing.T) {
 			isCmdFailFast:                 true,
 			msgGreeting:                   "msgGreeting",
 			msgInvalidCmd:                 "msgInvalidCmd",
+			msgQuitCmd:                    "msgQuitCmd",
 			msgInvalidCmdHeloSequence:     "msgInvalidCmdHeloSequence",
 			msgInvalidCmdHeloArg:          "msgInvalidCmdHeloArg",
 			msgHeloBlacklistedDomain:      "msgHeloBlacklistedDomain",
@@ -41,9 +53,15 @@ func TestNewConfiguration(t *testing.T) {
 			msgInvalidCmdMailfromArg:      "msgInvalidCmdMailfromArg",
 			msgMailfromBlacklistedEmail:   "msgMailfromBlacklistedEmail",
 			msgMailfromReceived:           "msgMailfromReceived",
-			msgQuit:                       "msgQuit",
+			msgInvalidCmdRcpttoSequence:   "msgInvalidCmdRcpttoSequence",
+			msgInvalidCmdRcpttoArg:        "msgInvalidCmdRcpttoArg",
+			msgRcpttoNotRegistredEmail:    "msgRcpttoNotRegistredEmail",
+			msgRcpttoBlacklistedEmail:     "msgRcpttoBlacklistedEmail",
+			msgRcpttoReceived:             "msgRcpttoReceived",
 			blacklistedHeloDomains:        []string{},
 			blacklistedMailfromEmails:     []string{},
+			registredRcpttoEmails:         []string{},
+			blacklistedRcpttoEmails:       []string{},
 		}
 		buildedConfiguration := NewConfiguration(configAttr)
 
@@ -51,17 +69,28 @@ func TestNewConfiguration(t *testing.T) {
 		assert.Equal(t, configAttr.isCmdFailFast, buildedConfiguration.isCmdFailFast)
 		assert.Equal(t, configAttr.msgGreeting, buildedConfiguration.msgGreeting)
 		assert.Equal(t, configAttr.msgInvalidCmd, buildedConfiguration.msgInvalidCmd)
+		assert.Equal(t, configAttr.msgQuitCmd, buildedConfiguration.msgQuitCmd)
+
 		assert.Equal(t, configAttr.msgInvalidCmdHeloSequence, buildedConfiguration.msgInvalidCmdHeloSequence)
 		assert.Equal(t, configAttr.msgInvalidCmdHeloArg, buildedConfiguration.msgInvalidCmdHeloArg)
 		assert.Equal(t, configAttr.msgHeloBlacklistedDomain, buildedConfiguration.msgHeloBlacklistedDomain)
 		assert.Equal(t, configAttr.msgHeloReceived, buildedConfiguration.msgHeloReceived)
+
 		assert.Equal(t, configAttr.msgInvalidCmdMailfromSequence, buildedConfiguration.msgInvalidCmdMailfromSequence)
 		assert.Equal(t, configAttr.msgInvalidCmdMailfromArg, buildedConfiguration.msgInvalidCmdMailfromArg)
 		assert.Equal(t, configAttr.msgMailfromBlacklistedEmail, buildedConfiguration.msgMailfromBlacklistedEmail)
 		assert.Equal(t, configAttr.msgMailfromReceived, buildedConfiguration.msgMailfromReceived)
-		assert.Equal(t, configAttr.msgQuit, buildedConfiguration.msgQuit)
+
+		assert.Equal(t, configAttr.msgInvalidCmdRcpttoSequence, buildedConfiguration.msgInvalidCmdRcpttoSequence)
+		assert.Equal(t, configAttr.msgInvalidCmdRcpttoArg, buildedConfiguration.msgInvalidCmdRcpttoArg)
+		assert.Equal(t, configAttr.msgRcpttoNotRegistredEmail, buildedConfiguration.msgRcpttoNotRegistredEmail)
+		assert.Equal(t, configAttr.msgRcpttoBlacklistedEmail, buildedConfiguration.msgRcpttoBlacklistedEmail)
+		assert.Equal(t, configAttr.msgRcpttoReceived, buildedConfiguration.msgRcpttoReceived)
+
 		assert.Equal(t, configAttr.blacklistedHeloDomains, buildedConfiguration.blacklistedHeloDomains)
 		assert.Equal(t, configAttr.blacklistedMailfromEmails, buildedConfiguration.blacklistedMailfromEmails)
+		assert.Equal(t, configAttr.registredRcpttoEmails, buildedConfiguration.registredRcpttoEmails)
+		assert.Equal(t, configAttr.blacklistedRcpttoEmails, buildedConfiguration.blacklistedRcpttoEmails)
 	})
 }
 
@@ -72,14 +101,22 @@ func TestConfigurationAttrAssignDefaultValues(t *testing.T) {
 
 		assert.Equal(t, DefaultGreetingMsg, configurationAttr.msgGreeting)
 		assert.Equal(t, DefaultInvalidCmdMsg, configurationAttr.msgInvalidCmd)
+		assert.Equal(t, DefaultQuitMsg, configurationAttr.msgQuitCmd)
+
 		assert.Equal(t, DefaultInvalidCmdHeloSequenceMsg, configurationAttr.msgInvalidCmdHeloSequence)
 		assert.Equal(t, DefaultInvalidCmdHeloArgMsg, configurationAttr.msgInvalidCmdHeloArg)
 		assert.Equal(t, DefaultQuitMsg, configurationAttr.msgHeloBlacklistedDomain)
 		assert.Equal(t, DefaultReceivedMsg, configurationAttr.msgHeloReceived)
+
 		assert.Equal(t, DefaultInvalidCmdMailfromSequenceMsg, configurationAttr.msgInvalidCmdMailfromSequence)
 		assert.Equal(t, DefaultInvalidCmdMailfromArgMsg, configurationAttr.msgInvalidCmdMailfromArg)
 		assert.Equal(t, DefaultQuitMsg, configurationAttr.msgMailfromBlacklistedEmail)
 		assert.Equal(t, DefaultReceivedMsg, configurationAttr.msgMailfromReceived)
-		assert.Equal(t, DefaultQuitMsg, configurationAttr.msgQuit)
+
+		assert.Equal(t, DefaultInvalidCmdRcpttoSequenceMsg, configurationAttr.msgInvalidCmdRcpttoSequence)
+		assert.Equal(t, DefaultInvalidCmdRcpttoArgMsg, configurationAttr.msgInvalidCmdRcpttoArg)
+		assert.Equal(t, DefaultNotRegistredRcpttoEmailMsg, configurationAttr.msgRcpttoNotRegistredEmail)
+		assert.Equal(t, DefaultQuitMsg, configurationAttr.msgRcpttoBlacklistedEmail)
+		assert.Equal(t, DefaultReceivedMsg, configurationAttr.msgRcpttoReceived)
 	})
 }

--- a/consts.go
+++ b/consts.go
@@ -9,9 +9,12 @@ const (
 	DefaultReceivedMsg                   = "250 Received"
 	DefaultInvalidCmdHeloArgMsg          = "501 HELO requires domain address"
 	DefaultInvalidCmdMailfromArgMsg      = "501 MAIL FROM requires valid email address"
+	DefaultInvalidCmdRcpttoArgMsg        = "501 RCPT TO requires valid email address"
 	DefaultInvalidCmdMsg                 = "502 Command unrecognized. Available commands: HELO, EHLO, MAIL FROM:, RCPT TO:"
 	DefaultInvalidCmdHeloSequenceMsg     = "503 Bad sequence of commands. HELO should be the first"
-	DefaultInvalidCmdMailfromSequenceMsg = "503 Bad sequence of commands. MAIL FROM should used after HELO"
+	DefaultInvalidCmdMailfromSequenceMsg = "503 Bad sequence of commands. MAIL FROM should be used after HELO"
+	DefaultInvalidCmdRcpttoSequenceMsg   = "503 Bad sequence of commands. RCPT TO should be used after MAIL FROM"
+	DefaultNotRegistredRcpttoEmailMsg    = "550 User not found"
 	DefaultQuitMsg                       = "221 Closing connection"
 
 	// Logger
@@ -43,7 +46,7 @@ const (
 	ValidMailfromCmdRegexPattern = `(?i)mail from:`
 	DomainRegexPattern           = `(?i)([\p{L}0-9]+([\-.]{1}[\p{L}0-9]+)*\.\p{L}{2,63})`
 	ValidHeloCmdRegexPattern     = `\A(?i)(helo|ehlo) ` + `(` + DomainRegexPattern + `)\z`
-	EmailRegexPattern            = `(?i)(.+)@` + DomainRegexPattern
+	EmailRegexPattern            = `(?i)<?((.+)@` + DomainRegexPattern + `)>?`
 	ValidMaifromCmdRegexPattern  = `\A(?i)(mail from:) ` + `(` + EmailRegexPattern + `)\z`
 
 	// Helpers

--- a/handler_helo_test.go
+++ b/handler_helo_test.go
@@ -404,7 +404,7 @@ func TestHandlerHeloIsBlacklistedDomain(t *testing.T) {
 	t.Run("when request includes blacklisted domain name", func(t *testing.T) {
 		session, message, configuration := new(sessionMock), new(message), createConfiguration()
 		configuration.blacklistedHeloDomains = []string{domainName}
-		errorMessage := configuration.msgQuit
+		errorMessage := configuration.msgQuitCmd
 		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
 		session.On("writeResponse", errorMessage).Once().Return(nil)

--- a/handler_mailfrom.go
+++ b/handler_mailfrom.go
@@ -103,7 +103,7 @@ func (handler *handlerMailfrom) isInvalidRequest(request string) bool {
 
 // Returns domain from HELO request
 func (handler *handlerMailfrom) mailfromEmail(request string) string {
-	return regexCaptureGroup(request, ValidMaifromCmdRegexPattern, 2)
+	return regexCaptureGroup(request, ValidMaifromCmdRegexPattern, 3)
 }
 
 // Custom behaviour for HELO domain predicate. Returns true and writes result for case when HELO domain

--- a/handler_mailfrom_test.go
+++ b/handler_mailfrom_test.go
@@ -315,11 +315,21 @@ func TestHandlerMaifromIsInvalidCmdArg(t *testing.T) {
 		assert.Equal(t, errorMessage, message.mailfromResponse)
 	})
 
-	t.Run("when request includes valid command MAILFROM argument", func(t *testing.T) {
+	t.Run("when request includes valid command MAILFROM argument without <> sign", func(t *testing.T) {
 		message := new(message)
 		handler := newHandlerMailfrom(session, message, configuration)
 
 		assert.False(t, handler.isInvalidCmdArg("MAIL FROM: user@example.com"))
+		assert.False(t, message.mailfrom)
+		assert.Empty(t, message.mailfromRequest)
+		assert.Empty(t, message.mailfromResponse)
+	})
+
+	t.Run("when request includes valid command MAILFROM argument with <> sign", func(t *testing.T) {
+		message := new(message)
+		handler := newHandlerMailfrom(session, message, configuration)
+
+		assert.False(t, handler.isInvalidCmdArg("MAIL FROM: <user@example.com>"))
 		assert.False(t, message.mailfrom)
 		assert.Empty(t, message.mailfromRequest)
 		assert.Empty(t, message.mailfromResponse)
@@ -383,13 +393,19 @@ func TestHandlerMailfromIsInvalidRequest(t *testing.T) {
 func TestHandlerMailfromMailfromEmail(t *testing.T) {
 	handler := new(handlerMailfrom)
 
-	t.Run("when request includes valid email", func(t *testing.T) {
+	t.Run("when request includes valid email address without <> sign", func(t *testing.T) {
 		validEmail := "user@example.com"
 
 		assert.Equal(t, validEmail, handler.mailfromEmail("MAIL FROM: "+validEmail))
 	})
 
-	t.Run("when request not includes valid domain name", func(t *testing.T) {
+	t.Run("when request includes valid email address with <> sign", func(t *testing.T) {
+		validEmail := "user@example.com"
+
+		assert.Equal(t, validEmail, handler.mailfromEmail("MAIL FROM: "+"<"+validEmail+">"))
+	})
+
+	t.Run("when request includes invalid email address", func(t *testing.T) {
 		invalidEmail := "user@invalid"
 
 		assert.Equal(t, EmptyString, handler.mailfromEmail("MAIL FROM: "+invalidEmail))


### PR DESCRIPTION
- [x] Implemented ability to use mailfrom commands with <> sign for `handlerMailfrom`
- [x] Refactored consts
- [x] Refactored `configuration`, tests