### PR TITLE
Feature/Assigning random SMTP port by OS as default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,28 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2021-12-07
+
+### Added
+
+- Added ability to assign random SMTP port number by OS as default settings
+- Added `Server.PortNumber` field
+
+### Changed
+
+- Updated`Server#Start` method, tests
+- Refactored `ConfigurationAttr#assignDefaultValues` method
+- Updated `ConfigurationAttr#assignServerDefaultValues` method, tests
+- Updated package docs
+- Updated linters config
+
+### Removed
+
+- Removed `defaultPortNuber`
+
 ## [0.1.2] - 2021-12-03
 
-### Updated
+### Changed
 
 - Updated functions/structures/consts scopes
 - Updated linters config

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ smtpmock.ConfigurationAttr{
   // Host address where smtpmock will run, it's equal to "127.0.0.1" by default
   hostAddress:                   "[::]",
 
-  // Port number on which the server will bind, it's equal to 2525 by default
-  portNumber:                    2526,
+  // Port number on which the server will bind. If it not specified, it will be
+  // assigned dynamically after server.Start() by default
+  portNumber:                    2525,
 
   // Enables/disables log to stdout. It's equal to false by default
   logToStdout:                   true,
@@ -202,12 +203,8 @@ import (
 )
 
 func main() {
-  hostAddress, portNumber := "127.0.0.1", 2525
-
   // You can pass empty smtpmock.ConfigurationAttr{}. It means that smtpmock will use default settings
   server := smtpmock.New(smtpmock.ConfigurationAttr{
-    hostAddress:       hostAddress,
-    portNumber:        portNumber,
     logToStdout:       true,
     logServerActivity: true,
   })
@@ -216,6 +213,10 @@ func main() {
   if err := server.Start(); err != nil {
     fmt.Println(err)
   }
+
+  // Server's port will be assigned dynamically after server.Start()
+  // for case when portNumber wasn't specified
+  portNumber =: server.PortNumber
 
   // Possible SMTP-client stuff for iteration with mock server
   address := fmt.Sprintf("%s:%d", hostAddress, portNumber)

--- a/configuration.go
+++ b/configuration.go
@@ -120,9 +120,6 @@ func (config *ConfigurationAttr) assignServerDefaultValues() {
 	if config.hostAddress == emptyString {
 		config.hostAddress = defaultHostAddress
 	}
-	if config.portNumber == 0 {
-		config.portNumber = defaultPortNuber
-	}
 	if config.msgGreeting == emptyString {
 		config.msgGreeting = defaultGreetingMsg
 	}

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -12,7 +12,6 @@ func TestNewConfiguration(t *testing.T) {
 		buildedConfiguration := newConfiguration(ConfigurationAttr{})
 
 		assert.Equal(t, defaultHostAddress, buildedConfiguration.hostAddress)
-		assert.Equal(t, defaultPortNuber, buildedConfiguration.portNumber)
 		assert.False(t, buildedConfiguration.logToStdout)
 		assert.False(t, buildedConfiguration.isCmdFailFast)
 		assert.False(t, buildedConfiguration.logServerActivity)
@@ -132,7 +131,6 @@ func TestConfigurationAttrAssignDefaultValues(t *testing.T) {
 		configurationAttr.assignDefaultValues()
 
 		assert.Equal(t, defaultHostAddress, configurationAttr.hostAddress)
-		assert.Equal(t, defaultPortNuber, configurationAttr.portNumber)
 		assert.Equal(t, defaultGreetingMsg, configurationAttr.msgGreeting)
 		assert.Equal(t, defaultInvalidCmdMsg, configurationAttr.msgInvalidCmd)
 		assert.Equal(t, defaultQuitMsg, configurationAttr.msgQuitCmd)

--- a/consts.go
+++ b/consts.go
@@ -35,7 +35,6 @@ const (
 	// Server
 	networkProtocol                  = "tcp"
 	defaultHostAddress               = "0.0.0.0"
-	defaultPortNuber                 = 2525
 	defaultMessageSizeLimit          = 10485760 // in bytes (10MB)
 	defaultSessionTimeout            = 30       // in seconds
 	serverStartMsg                   = "SMTP mock server started on port"

--- a/smtpmock_test.go
+++ b/smtpmock_test.go
@@ -13,7 +13,6 @@ func TestNew(t *testing.T) {
 		configuration := server.configuration
 
 		assert.Equal(t, defaultHostAddress, configuration.hostAddress)
-		assert.Equal(t, defaultPortNuber, configuration.portNumber)
 		assert.False(t, configuration.logToStdout)
 		assert.False(t, configuration.isCmdFailFast)
 		assert.False(t, configuration.logServerActivity)
@@ -151,11 +150,12 @@ func TestNew(t *testing.T) {
 
 		assert.NoError(t, server.Start())
 		assert.True(t, server.isStarted)
-		_ = runMinimalSuccessfulSMTPSession(configuration.hostAddress, configuration.portNumber)
+		_ = runMinimalSuccessfulSMTPSession(configuration.hostAddress, server.PortNumber)
 		_ = server.Stop()
 
 		assert.NotEmpty(t, server.messages)
 		assert.NotNil(t, server.quit)
 		assert.False(t, server.isStarted)
+		assert.Greater(t, server.PortNumber, 0)
 	})
 }


### PR DESCRIPTION
- [x] Added ability to assign random SMTP port number by OS as default settings
- [x] Added `Server.PortNumber`
- [x] Updated `Server#Start method`, tests
- [x] Updated `ConfigurationAttr#assignServerDefaultValues` method, tests
- [x] Updated linters config
- [x] Updated package docs, changelog