### PR TITLE
Feature/RFC compatibility for default negative SMTP command responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2021-12-11
+
+### Changed
+
+- Updated default negative SMTP command responses follows to RFC
+- Updated `ConfigurationAttr` methods, tests
+
 ## [1.0.1] - 2021-12-10
 
 ### Fixed

--- a/configuration.go
+++ b/configuration.go
@@ -143,7 +143,7 @@ func (config *ConfigurationAttr) assignHandlerHeloDefaultValues() {
 		config.MsgInvalidCmdHeloArg = defaultInvalidCmdHeloArgMsg
 	}
 	if config.MsgHeloBlacklistedDomain == emptyString {
-		config.MsgHeloBlacklistedDomain = defaultQuitMsg
+		config.MsgHeloBlacklistedDomain = defaultTransientNegativeMsg
 	}
 	if config.MsgHeloReceived == emptyString {
 		config.MsgHeloReceived = defaultReceivedMsg
@@ -159,7 +159,7 @@ func (config *ConfigurationAttr) assignHandlerMailfromDefaultValues() {
 		config.MsgInvalidCmdMailfromArg = defaultInvalidCmdMailfromArgMsg
 	}
 	if config.MsgMailfromBlacklistedEmail == emptyString {
-		config.MsgMailfromBlacklistedEmail = defaultQuitMsg
+		config.MsgMailfromBlacklistedEmail = defaultTransientNegativeMsg
 	}
 	if config.MsgMailfromReceived == emptyString {
 		config.MsgMailfromReceived = defaultReceivedMsg
@@ -175,7 +175,7 @@ func (config *ConfigurationAttr) assignHandlerRcpttoDefaultValues() {
 		config.MsgInvalidCmdRcpttoArg = defaultInvalidCmdRcpttoArgMsg
 	}
 	if config.MsgRcpttoBlacklistedEmail == emptyString {
-		config.MsgRcpttoBlacklistedEmail = defaultQuitMsg
+		config.MsgRcpttoBlacklistedEmail = defaultTransientNegativeMsg
 	}
 	if config.MsgRcpttoNotRegisteredEmail == emptyString {
 		config.MsgRcpttoNotRegisteredEmail = defaultNotRegistredRcpttoEmailMsg

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -22,17 +22,17 @@ func TestNewConfiguration(t *testing.T) {
 
 		assert.Equal(t, defaultInvalidCmdHeloSequenceMsg, buildedConfiguration.msgInvalidCmdHeloSequence)
 		assert.Equal(t, defaultInvalidCmdHeloArgMsg, buildedConfiguration.msgInvalidCmdHeloArg)
-		assert.Equal(t, defaultQuitMsg, buildedConfiguration.msgHeloBlacklistedDomain)
+		assert.Equal(t, defaultTransientNegativeMsg, buildedConfiguration.msgHeloBlacklistedDomain)
 		assert.Equal(t, defaultReceivedMsg, buildedConfiguration.msgHeloReceived)
 
 		assert.Equal(t, defaultInvalidCmdMailfromSequenceMsg, buildedConfiguration.msgInvalidCmdMailfromSequence)
 		assert.Equal(t, defaultInvalidCmdMailfromArgMsg, buildedConfiguration.msgInvalidCmdMailfromArg)
-		assert.Equal(t, defaultQuitMsg, buildedConfiguration.msgMailfromBlacklistedEmail)
+		assert.Equal(t, defaultTransientNegativeMsg, buildedConfiguration.msgMailfromBlacklistedEmail)
 		assert.Equal(t, defaultReceivedMsg, buildedConfiguration.msgMailfromReceived)
 
 		assert.Equal(t, defaultInvalidCmdRcpttoSequenceMsg, buildedConfiguration.msgInvalidCmdRcpttoSequence)
 		assert.Equal(t, defaultInvalidCmdRcpttoArgMsg, buildedConfiguration.msgInvalidCmdRcpttoArg)
-		assert.Equal(t, defaultQuitMsg, buildedConfiguration.msgRcpttoBlacklistedEmail)
+		assert.Equal(t, defaultTransientNegativeMsg, buildedConfiguration.msgRcpttoBlacklistedEmail)
 		assert.Equal(t, defaultNotRegistredRcpttoEmailMsg, buildedConfiguration.msgRcpttoNotRegisteredEmail)
 		assert.Equal(t, defaultReceivedMsg, buildedConfiguration.msgRcpttoReceived)
 
@@ -138,17 +138,17 @@ func TestConfigurationAttrAssignDefaultValues(t *testing.T) {
 
 		assert.Equal(t, defaultInvalidCmdHeloSequenceMsg, configurationAttr.MsgInvalidCmdHeloSequence)
 		assert.Equal(t, defaultInvalidCmdHeloArgMsg, configurationAttr.MsgInvalidCmdHeloArg)
-		assert.Equal(t, defaultQuitMsg, configurationAttr.MsgHeloBlacklistedDomain)
+		assert.Equal(t, defaultTransientNegativeMsg, configurationAttr.MsgHeloBlacklistedDomain)
 		assert.Equal(t, defaultReceivedMsg, configurationAttr.MsgHeloReceived)
 
 		assert.Equal(t, defaultInvalidCmdMailfromSequenceMsg, configurationAttr.MsgInvalidCmdMailfromSequence)
 		assert.Equal(t, defaultInvalidCmdMailfromArgMsg, configurationAttr.MsgInvalidCmdMailfromArg)
-		assert.Equal(t, defaultQuitMsg, configurationAttr.MsgMailfromBlacklistedEmail)
+		assert.Equal(t, defaultTransientNegativeMsg, configurationAttr.MsgMailfromBlacklistedEmail)
 		assert.Equal(t, defaultReceivedMsg, configurationAttr.MsgMailfromReceived)
 
 		assert.Equal(t, defaultInvalidCmdRcpttoSequenceMsg, configurationAttr.MsgInvalidCmdRcpttoSequence)
 		assert.Equal(t, defaultInvalidCmdRcpttoArgMsg, configurationAttr.MsgInvalidCmdRcpttoArg)
-		assert.Equal(t, defaultQuitMsg, configurationAttr.MsgRcpttoBlacklistedEmail)
+		assert.Equal(t, defaultTransientNegativeMsg, configurationAttr.MsgRcpttoBlacklistedEmail)
 		assert.Equal(t, defaultNotRegistredRcpttoEmailMsg, configurationAttr.MsgRcpttoNotRegisteredEmail)
 		assert.Equal(t, defaultReceivedMsg, configurationAttr.MsgRcpttoReceived)
 

--- a/consts.go
+++ b/consts.go
@@ -8,6 +8,7 @@ const (
 	defaultQuitMsg                       = "221 Closing connection"
 	defaultReceivedMsg                   = "250 Received"
 	defaultReadyForReceiveMsg            = "354 Ready for receive message. End data with <CR><LF>.<CR><LF>"
+	defaultTransientNegativeMsg          = "421 Service not available"
 	defaultInvalidCmdHeloArgMsg          = "501 HELO requires domain address"
 	defaultInvalidCmdMailfromArgMsg      = "501 MAIL FROM requires valid email address"
 	defaultInvalidCmdRcpttoArgMsg        = "501 RCPT TO requires valid email address"

--- a/handler_helo_test.go
+++ b/handler_helo_test.go
@@ -163,7 +163,7 @@ func TestHandlerHeloIsBlacklistedDomain(t *testing.T) {
 	t.Run("when request includes blacklisted domain name", func(t *testing.T) {
 		session, message, configuration := new(sessionMock), new(message), createConfiguration()
 		configuration.blacklistedHeloDomains = []string{domainName}
-		errorMessage := configuration.msgQuitCmd
+		errorMessage := configuration.msgHeloBlacklistedDomain
 		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
 		session.On("writeResponse", errorMessage).Once().Return(nil)

--- a/smtpmock_test.go
+++ b/smtpmock_test.go
@@ -23,17 +23,17 @@ func TestNew(t *testing.T) {
 
 		assert.Equal(t, defaultInvalidCmdHeloSequenceMsg, configuration.msgInvalidCmdHeloSequence)
 		assert.Equal(t, defaultInvalidCmdHeloArgMsg, configuration.msgInvalidCmdHeloArg)
-		assert.Equal(t, defaultQuitMsg, configuration.msgHeloBlacklistedDomain)
+		assert.Equal(t, defaultTransientNegativeMsg, configuration.msgHeloBlacklistedDomain)
 		assert.Equal(t, defaultReceivedMsg, configuration.msgHeloReceived)
 
 		assert.Equal(t, defaultInvalidCmdMailfromSequenceMsg, configuration.msgInvalidCmdMailfromSequence)
 		assert.Equal(t, defaultInvalidCmdMailfromArgMsg, configuration.msgInvalidCmdMailfromArg)
-		assert.Equal(t, defaultQuitMsg, configuration.msgMailfromBlacklistedEmail)
+		assert.Equal(t, defaultTransientNegativeMsg, configuration.msgMailfromBlacklistedEmail)
 		assert.Equal(t, defaultReceivedMsg, configuration.msgMailfromReceived)
 
 		assert.Equal(t, defaultInvalidCmdRcpttoSequenceMsg, configuration.msgInvalidCmdRcpttoSequence)
 		assert.Equal(t, defaultInvalidCmdRcpttoArgMsg, configuration.msgInvalidCmdRcpttoArg)
-		assert.Equal(t, defaultQuitMsg, configuration.msgRcpttoBlacklistedEmail)
+		assert.Equal(t, defaultTransientNegativeMsg, configuration.msgRcpttoBlacklistedEmail)
 		assert.Equal(t, defaultNotRegistredRcpttoEmailMsg, configuration.msgRcpttoNotRegisteredEmail)
 		assert.Equal(t, defaultReceivedMsg, configuration.msgRcpttoReceived)
 


### PR DESCRIPTION
- [x] Updated `ConfigurationAttr` methods, tests
- [x] Updated consts
- [x] Updated changelog