### PR TITLE
Bugfix/Fix variables order in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ func main() {
 
   // Server's port will be assigned dynamically after server.Start()
   // for case when portNumber wasn't specified
-  hostAddress, portNumber =: server.PortNumber, "127.0.0.1"
+  hostAddress, portNumber =: "127.0.0.1", server.PortNumber
 
   // Possible SMTP-client stuff for iteration with mock server
   address := fmt.Sprintf("%s:%d", hostAddress, portNumber)


### PR DESCRIPTION
# PR Details
Fix the wrong order of variables in README.md.

## Description

Changed order of `hostAddress` and `portNumber` variables values.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> https://github.com/mocktools/go-smtp-mock/issues/57

## Motivation and Context

It will make an example to be a correct one.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/mocktools/go-smtp-mock/blob/master/CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] I have run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I have run `rubocop` and `reek` to ensure the code style is valid
