### PR TITLE
Feature/Ability to shutdown server with SIGQUIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2022-02-21
+
+### Added
+
+- Ability to shutdown `smtpmock` server with `SIGQUIT`
+
+### Updated
+
+- Updated package documentation
+
 ## [1.5.2] - 2022-01-29
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   - [Inside of any ecosystem](#inside-of-any-ecosystem)
     - [Configuring with command line arguments](#configuring-with-command-line-arguments)
     - [Other options](#other-options)
+    - [Stopping server](#stopping-server)
 - [Contributing](#contributing)
 - [License](#license)
 - [Code of Conduct](#code-of-conduct)
@@ -354,6 +355,10 @@ Available not configuration `smtpmock` options:
 | Flag description | Example of usage |
 | --- | --- |
 | `-v` - Just prints current `smtpmock` binary build data (version, commit, datetime). Doesn't run the server. | `-v` |
+
+#### Stopping server
+
+`smtpmock` accepts 3 shutdown signals: `SIGINT`, `SIGQUIT`, `SIGTERM`.
 
 ## Contributing
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,7 +41,7 @@ func run(args []string, options ...flag.ErrorHandling) error {
 	}
 
 	server := smtpmock.New(*configAttr)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 
 	if err := server.Start(); err != nil {
 		return err

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -43,8 +43,20 @@ func TestRun(t *testing.T) {
 		assert.Error(t, run([]string{path, "-host=a"}))
 	})
 
-	t.Run("when server was started successfully, terminate signal received", func(t *testing.T) {
+	t.Run("when server was started successfully, interrupt signal (exit 2) received", func(t *testing.T) {
 		signals <- syscall.SIGINT
+
+		assert.NoError(t, run([]string{path}))
+	})
+
+	t.Run("when server was started successfully, quit signal (exit 3) received", func(t *testing.T) {
+		signals <- syscall.SIGQUIT
+
+		assert.NoError(t, run([]string{path}))
+	})
+
+	t.Run("when server was started successfully, terminated signal (exit 15) received", func(t *testing.T) {
+		signals <- syscall.SIGTERM
 
 		assert.NoError(t, run([]string{path}))
 	})


### PR DESCRIPTION
- [x] Added ability to shutdown `smtpmock` server with `SIGQUIT`
- [x] Updated documentation
- [x] Updated changelog