### PR TITLE
Feature/Ability to specify session response delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2022-02-22
+
+### Added
+
+- Ability to specify session response delay for each SMTP command
+
+### Updated
+
+- Updated `configuration`, `ConfigurationAttr` tests
+- Updated consts
+- Updated `session` structure methods, tests
+- Updated `server#handleSession`, tests
+- Updated `handlerHelo#writeResult`, tests
+- Updated `handlerMailfrom#writeResult`, tests
+- Updated `handlerRcptto#writeResult`, tests
+- Updated `handlerData#writeResult`, tests
+- Updated `handlerMessage#writeResult`, tests
+- Updated `handlerQuit#writeResult`, tests
+- Updated `main.attrFromCommandLine()`, tests
+- Updated package documentation
+
 ## [1.6.0] - 2022-02-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,9 +133,33 @@ smtpmock.ConfigurationAttr{
   // It's equal to empty []string
   NotRegisteredEmails:           []string{"nobody@olo.com", "non-existent@email.com"},
 
+  // Ability to specify HELO response delay in seconds. It runs immediately,
+  // equals to 0 seconds by default
+  ResponseDelayHelo:             2,
+
+  // Ability to specify MAIL FROM response delay in seconds. It runs immediately,
+  // equals to 0 seconds by default
+  ResponseDelayMailfrom:         2,
+
+  // Ability to specify RCPT TO response delay in seconds. It runs immediately,
+  // equals to 0 seconds by default
+  ResponseDelayRcptto:           2,
+
+  // Ability to specify DATA response delay in seconds. It runs immediately,
+  // equals to 0 seconds by default
+  ResponseDelayData:             2,
+
+  // Ability to specify message response delay in seconds. It runs immediately,
+  // equals to 0 seconds by default
+  ResponseDelayMessage:          2,
+
+  // Ability to specify QUIT response delay in seconds. It runs immediately,
+  // equals to 0 seconds by default
+  ResponseDelayQuit:             2,
+
   // Ability to specify message body size limit. It's equal to 10485760 bytes (10MB) by default
   MsgSizeLimit:                  5,
-  
+
 
   // Customazing SMTP command handler messages context
   // ---------------------------------------------------------------------
@@ -326,6 +350,12 @@ curl -sL https://raw.githubusercontent.com/mocktools/go-smtp-mock/master/script/
 | `-blacklistedMailfromEmails` - blacklisted `MAIL FROM` emails, separated by commas | `-blacklistedMailfromEmails="a@example1.com,b@example2.com"` |
 | `-blacklistedRcpttoEmails` - blacklisted `RCPT TO` emails, separated by commas | `-blacklistedRcpttoEmails="a@example1.com,b@example2.com"` |
 | `-notRegisteredEmails` - not registered (non-existent) `RCPT TO` emails, separated by commas | `-notRegisteredEmails="a@example1.com,b@example2.com"` |
+| `-responseDelayHelo` - `HELO` response delay in seconds. It's equal to 0 seconds by default | `-responseDelayHelo=2` |
+| `-responseDelayMailfrom` - `MAIL FROM` response delay in seconds. It's equal to 0 seconds by default | `-responseDelayMailfrom=2` |
+| `-responseDelayRcptto` - `RCPT TO` response delay in seconds. It's equal to 0 seconds by default | `-responseDelayRcptto=2` |
+| `-responseDelayData` - `DATA` response delay in seconds. It's equal to 0 seconds by default | `-responseDelayData=2` |
+| `-responseDelayMessage` - Message response delay in seconds. It's equal to 0 seconds by default | `-responseDelayMessage=2` |
+| `-responseDelayQuit` - `QUIT` response delay in seconds. It's equal to 0 seconds by default | `-responseDelayQuit=2` |
 | `-msgSizeLimit` - message body size limit in bytes. It's equal to `10485760` bytes | `-msgSizeLimit=42` |
 | `-msgGreeting` - custom server greeting message | `-msgGreeting="Greeting message"` |
 | `-msgInvalidCmd` - custom invalid command message | `-msgInvalidCmd="Invalid command message"` |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,10 @@ import (
 	version "github.com/mocktools/go-smtp-mock/cmd/version"
 )
 
+const (
+	responseDelayFlagInfo = " response delay in seconds. It runs immediately (equals to 0 seconds) by default"
+)
+
 var signals, logFatalf = make(chan os.Signal, 1), log.Fatalf
 
 // Main entrypoint
@@ -88,6 +92,12 @@ func attrFromCommandLine(args []string, options ...flag.ErrorHandling) (bool, *s
 		blacklistedMailfromEmails     = flags.String("blacklistedMailfromEmails", "", "Blacklisted MAIL FROM emails, separated by commas")
 		blacklistedRcpttoEmails       = flags.String("blacklistedRcpttoEmails", "", "Blacklisted RCPT TO emails, separated by commas")
 		notRegisteredEmails           = flags.String("notRegisteredEmails", "", "Not registered (non-existent) RCPT TO emails, separated by commas")
+		responseDelayHelo             = flags.Int("responseDelayHelo", 0, "HELO"+responseDelayFlagInfo)
+		responseDelayMailfrom         = flags.Int("responseDelayMailfrom", 0, "MAIL FROM"+responseDelayFlagInfo)
+		responseDelayRcptto           = flags.Int("responseDelayRcptto", 0, "RCPT TO"+responseDelayFlagInfo)
+		responseDelayData             = flags.Int("responseDelayData", 0, "DATA"+responseDelayFlagInfo)
+		responseDelayMessage          = flags.Int("responseDelayMessage", 0, "Message"+responseDelayFlagInfo)
+		responseDelayQuit             = flags.Int("responseDelayQuit", 0, "QUIT"+responseDelayFlagInfo)
 		msgSizeLimit                  = flags.Int("msgSizeLimit", 0, "Message body size limit in bytes. It's equal to 10485760 bytes")
 		msgGreeting                   = flags.String("msgGreeting", "", "Custom server greeting message")
 		msgInvalidCmd                 = flags.String("msgInvalidCmd", "", "Custom invalid command message")
@@ -126,6 +136,12 @@ func attrFromCommandLine(args []string, options ...flag.ErrorHandling) (bool, *s
 		BlacklistedMailfromEmails:     toSlice(*blacklistedMailfromEmails),
 		BlacklistedRcpttoEmails:       toSlice(*blacklistedRcpttoEmails),
 		NotRegisteredEmails:           toSlice(*notRegisteredEmails),
+		ResponseDelayHelo:             *responseDelayHelo,
+		ResponseDelayMailfrom:         *responseDelayMailfrom,
+		ResponseDelayRcptto:           *responseDelayRcptto,
+		ResponseDelayData:             *responseDelayData,
+		ResponseDelayMessage:          *responseDelayMessage,
+		ResponseDelayQuit:             *responseDelayQuit,
 		MsgSizeLimit:                  *msgSizeLimit,
 		MsgGreeting:                   *msgGreeting,
 		MsgInvalidCmd:                 *msgInvalidCmd,

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -94,6 +94,12 @@ func TestAttrFromCommandLine(t *testing.T) {
 		blacklistedMailfromEmails := "a@a.com,b@b.com"
 		blacklistedRcpttoEmails := "c@a.com,d@b.com"
 		notRegisteredEmails := "non-existent@a.com"
+		responseDelayHelo := 1
+		responseDelayMailfrom := 2
+		responseDelayRcptto := 3
+		responseDelayData := 4
+		responseDelayMessage := 5
+		responseDelayQuit := 6
 		msgSizeLimit := 1000
 		msgGreeting := "msgGreeting"
 		msgInvalidCmd := "msgInvalidCmd"
@@ -129,6 +135,12 @@ func TestAttrFromCommandLine(t *testing.T) {
 				"-blacklistedMailfromEmails=" + blacklistedMailfromEmails,
 				"-blacklistedRcpttoEmails=" + blacklistedRcpttoEmails,
 				"-notRegisteredEmails=" + notRegisteredEmails,
+				"-responseDelayHelo=" + strconv.Itoa(responseDelayHelo),
+				"-responseDelayMailfrom=" + strconv.Itoa(responseDelayMailfrom),
+				"-responseDelayRcptto=" + strconv.Itoa(responseDelayRcptto),
+				"-responseDelayData=" + strconv.Itoa(responseDelayData),
+				"-responseDelayMessage=" + strconv.Itoa(responseDelayMessage),
+				"-responseDelayQuit=" + strconv.Itoa(responseDelayQuit),
 				"-msgSizeLimit=" + strconv.Itoa(msgSizeLimit),
 				"-msgGreeting=" + msgGreeting,
 				"-msgInvalidCmd=" + msgInvalidCmd,
@@ -165,6 +177,12 @@ func TestAttrFromCommandLine(t *testing.T) {
 		assert.Equal(t, toSlice(blacklistedMailfromEmails), configAttr.BlacklistedMailfromEmails)
 		assert.Equal(t, toSlice(blacklistedRcpttoEmails), configAttr.BlacklistedRcpttoEmails)
 		assert.Equal(t, toSlice(notRegisteredEmails), configAttr.NotRegisteredEmails)
+		assert.Equal(t, responseDelayHelo, configAttr.ResponseDelayHelo)
+		assert.Equal(t, responseDelayMailfrom, configAttr.ResponseDelayMailfrom)
+		assert.Equal(t, responseDelayRcptto, configAttr.ResponseDelayRcptto)
+		assert.Equal(t, responseDelayData, configAttr.ResponseDelayData)
+		assert.Equal(t, responseDelayMessage, configAttr.ResponseDelayMessage)
+		assert.Equal(t, responseDelayQuit, configAttr.ResponseDelayQuit)
 		assert.Equal(t, msgSizeLimit, configAttr.MsgSizeLimit)
 		assert.Equal(t, msgGreeting, configAttr.MsgGreeting)
 		assert.Equal(t, msgInvalidCmd, configAttr.MsgInvalidCmd)

--- a/configuration.go
+++ b/configuration.go
@@ -33,6 +33,12 @@ type configuration struct {
 	blacklistedMailfromEmails     []string
 	blacklistedRcpttoEmails       []string
 	notRegisteredEmails           []string
+	responseDelayHelo             int
+	responseDelayMailfrom         int
+	responseDelayRcptto           int
+	responseDelayData             int
+	responseDelayMessage          int
+	responseDelayQuit             int
 	msgSizeLimit                  int
 	sessionTimeout                int
 	shutdownTimeout               int
@@ -74,6 +80,12 @@ func newConfiguration(config ConfigurationAttr) *configuration {
 		blacklistedMailfromEmails:     config.BlacklistedMailfromEmails,
 		blacklistedRcpttoEmails:       config.BlacklistedRcpttoEmails,
 		notRegisteredEmails:           config.NotRegisteredEmails,
+		responseDelayHelo:             config.ResponseDelayHelo,
+		responseDelayMailfrom:         config.ResponseDelayMailfrom,
+		responseDelayRcptto:           config.ResponseDelayRcptto,
+		responseDelayData:             config.ResponseDelayData,
+		responseDelayMessage:          config.ResponseDelayMessage,
+		responseDelayQuit:             config.ResponseDelayQuit,
 		msgSizeLimit:                  config.MsgSizeLimit,
 		sessionTimeout:                config.SessionTimeout,
 		shutdownTimeout:               config.ShutdownTimeout,
@@ -111,6 +123,12 @@ type ConfigurationAttr struct {
 	BlacklistedMailfromEmails     []string
 	BlacklistedRcpttoEmails       []string
 	NotRegisteredEmails           []string
+	ResponseDelayHelo             int
+	ResponseDelayMailfrom         int
+	ResponseDelayRcptto           int
+	ResponseDelayData             int
+	ResponseDelayMessage          int
+	ResponseDelayQuit             int
 	MsgSizeLimit                  int
 	SessionTimeout                int
 	ShutdownTimeout               int

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -48,6 +48,13 @@ func TestNewConfiguration(t *testing.T) {
 		assert.Empty(t, buildedConfiguration.blacklistedMailfromEmails)
 		assert.Empty(t, buildedConfiguration.blacklistedRcpttoEmails)
 		assert.Empty(t, buildedConfiguration.notRegisteredEmails)
+
+		assert.Equal(t, defaultSessionResponseDelay, buildedConfiguration.responseDelayHelo)
+		assert.Equal(t, defaultSessionResponseDelay, buildedConfiguration.responseDelayMailfrom)
+		assert.Equal(t, defaultSessionResponseDelay, buildedConfiguration.responseDelayRcptto)
+		assert.Equal(t, defaultSessionResponseDelay, buildedConfiguration.responseDelayData)
+		assert.Equal(t, defaultSessionResponseDelay, buildedConfiguration.responseDelayMessage)
+		assert.Equal(t, defaultSessionResponseDelay, buildedConfiguration.responseDelayQuit)
 	})
 
 	t.Run("creates new configuration with custom settings", func(t *testing.T) {
@@ -81,6 +88,12 @@ func TestNewConfiguration(t *testing.T) {
 			BlacklistedMailfromEmails:     []string{},
 			NotRegisteredEmails:           []string{},
 			BlacklistedRcpttoEmails:       []string{},
+			ResponseDelayHelo:             2,
+			ResponseDelayMailfrom:         2,
+			ResponseDelayRcptto:           2,
+			ResponseDelayData:             2,
+			ResponseDelayMessage:          2,
+			ResponseDelayQuit:             2,
 			MsgSizeLimit:                  42,
 			SessionTimeout:                120,
 			ShutdownTimeout:               2,
@@ -125,6 +138,13 @@ func TestNewConfiguration(t *testing.T) {
 		assert.Equal(t, configAttr.BlacklistedMailfromEmails, buildedConfiguration.blacklistedMailfromEmails)
 		assert.Equal(t, configAttr.BlacklistedRcpttoEmails, buildedConfiguration.blacklistedRcpttoEmails)
 		assert.Equal(t, configAttr.NotRegisteredEmails, buildedConfiguration.notRegisteredEmails)
+
+		assert.Equal(t, configAttr.ResponseDelayHelo, buildedConfiguration.responseDelayHelo)
+		assert.Equal(t, configAttr.ResponseDelayMailfrom, buildedConfiguration.responseDelayMailfrom)
+		assert.Equal(t, configAttr.ResponseDelayRcptto, buildedConfiguration.responseDelayRcptto)
+		assert.Equal(t, configAttr.ResponseDelayData, buildedConfiguration.responseDelayData)
+		assert.Equal(t, configAttr.ResponseDelayMessage, buildedConfiguration.responseDelayMessage)
+		assert.Equal(t, configAttr.ResponseDelayQuit, buildedConfiguration.responseDelayQuit)
 	})
 }
 

--- a/consts.go
+++ b/consts.go
@@ -27,11 +27,12 @@ const (
 	logFlag         = log.Ldate | log.Lmicroseconds
 
 	// Session
-	sessionStartMsg      = "SMTP session started"
-	sessionRequestMsg    = "SMTP request: "
-	sessionResponseMsg   = "SMTP response: "
-	sessionEndMsg        = "SMTP session finished"
-	sessionBinaryDataMsg = "message binary data portion"
+	sessionStartMsg         = "SMTP session started"
+	sessionRequestMsg       = "SMTP request: "
+	sessionResponseMsg      = "SMTP response: "
+	sessionResponseDelayMsg = "SMTP response delay"
+	sessionEndMsg           = "SMTP session finished"
+	sessionBinaryDataMsg    = "message binary data portion"
 
 	// Server
 	networkProtocol                  = "tcp"
@@ -39,6 +40,7 @@ const (
 	defaultMessageSizeLimit          = 10485760 // in bytes (10MB)
 	defaultSessionTimeout            = 30       // in seconds
 	defaultShutdownTimeout           = 1        // in seconds
+	defaultSessionResponseDelay      = 0        // in seconds
 	serverStartMsg                   = "SMTP mock server started on port"
 	serverStartErrorMsg              = "unable to start SMTP mock server. Server must be inactive"
 	serverErrorMsg                   = "Failed to start SMTP mock server on port"

--- a/handler_data.go
+++ b/handler_data.go
@@ -64,7 +64,7 @@ func (handler *handlerData) writeResult(isSuccessful bool, request, response str
 	}
 
 	message.dataRequest, message.dataResponse, message.data = request, response, isSuccessful
-	session.writeResponse(response)
+	session.writeResponse(response, handler.configuration.responseDelayData)
 	return true
 }
 

--- a/handler_data_test.go
+++ b/handler_data_test.go
@@ -23,11 +23,11 @@ func TestHandlerDataRun(t *testing.T) {
 		request, session, message, configuration := "DATA", new(sessionMock), new(message), createConfiguration()
 		handlerMessage, receivedMessage := &handlerMessageMock{}, configuration.msgDataReceived
 		message.helo, message.mailfrom, message.rcptto = true, true, true
-		handler := newHandlerData(session, message, configuration)
+		handler, responseDelay := newHandlerData(session, message, configuration), configuration.responseDelayData
 		handler.handlerMessage = handlerMessage
 		session.On("clearError").Once().Return(nil)
-		session.On("writeResponse", defaultReadyForReceiveMsg).Once().Return(nil)
-		session.On("writeResponse", receivedMessage).Once().Return(nil)
+		session.On("writeResponse", defaultReadyForReceiveMsg, responseDelay).Once().Return(nil)
+		session.On("writeResponse", receivedMessage, responseDelay).Once().Return(nil)
 		handlerMessage.On("run").Once().Return(nil)
 		handler.run(request)
 
@@ -44,7 +44,7 @@ func TestHandlerDataRun(t *testing.T) {
 		handler, err := newHandlerData(session, message, configuration), errors.New(errorMessage)
 		session.On("clearError").Once().Return(nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayData).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.data)
@@ -61,7 +61,7 @@ func TestHandlerDataRun(t *testing.T) {
 		handler, err := newHandlerData(session, message, configuration), errors.New(errorMessage)
 		session.On("clearError").Once().Return(nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayData).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.data)
@@ -113,7 +113,7 @@ func TestHandlerDataWriteResult(t *testing.T) {
 	t.Run("when successful request received", func(t *testing.T) {
 		message := new(message)
 		handler := newHandlerData(session, message, configuration)
-		session.On("writeResponse", response).Once().Return(nil)
+		session.On("writeResponse", response, configuration.responseDelayData).Once().Return(nil)
 
 		assert.True(t, handler.writeResult(true, request, response))
 		assert.True(t, message.data)
@@ -125,7 +125,7 @@ func TestHandlerDataWriteResult(t *testing.T) {
 		message, err := new(message), errors.New(response)
 		handler := newHandlerData(session, message, configuration)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", response).Once().Return(nil)
+		session.On("writeResponse", response, configuration.responseDelayData).Once().Return(nil)
 
 		assert.True(t, handler.writeResult(false, request, response))
 		assert.False(t, message.data)
@@ -141,7 +141,7 @@ func TestHandlerDataIsInvalidCmdSequence(t *testing.T) {
 		message, errorMessage := new(message), configuration.msgInvalidCmdDataSequence
 		handler, err := newHandlerData(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayData).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidCmdSequence(request))
 		assert.False(t, message.data)
@@ -154,7 +154,7 @@ func TestHandlerDataIsInvalidCmdSequence(t *testing.T) {
 		message.helo, message.mailfrom = true, true
 		handler, err := newHandlerData(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayData).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidCmdSequence(request))
 		assert.False(t, message.data)
@@ -167,7 +167,7 @@ func TestHandlerDataIsInvalidCmdSequence(t *testing.T) {
 		message.helo = true
 		handler, err := newHandlerData(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayData).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidCmdSequence(request))
 		assert.False(t, message.data)
@@ -194,7 +194,7 @@ func TestHandlerDataIsInvalidCmd(t *testing.T) {
 		request, message, errorMessage := "DATA ", new(message), configuration.msgInvalidCmdDataSequence
 		handler, err := newHandlerData(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayData).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidCmdSequence(request))
 		assert.False(t, message.data)
@@ -220,7 +220,7 @@ func TestHandlerDataIsInvalidRequest(t *testing.T) {
 		message, errorMessage := new(message), configuration.msgInvalidCmdDataSequence
 		handler, err := newHandlerData(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayData).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidRequest(request))
 		assert.False(t, message.data)
@@ -233,7 +233,7 @@ func TestHandlerDataIsInvalidRequest(t *testing.T) {
 		message.helo, message.mailfrom, message.rcptto = true, true, true
 		handler, err := newHandlerData(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayData).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidRequest(request))
 		assert.False(t, message.data)

--- a/handler_helo.go
+++ b/handler_helo.go
@@ -40,7 +40,7 @@ func (handler *handlerHelo) writeResult(isSuccessful bool, request, response str
 	}
 
 	message.heloRequest, message.heloResponse, message.helo = request, response, isSuccessful
-	session.writeResponse(response)
+	session.writeResponse(response, handler.configuration.responseDelayHelo)
 	return true
 }
 

--- a/handler_helo_test.go
+++ b/handler_helo_test.go
@@ -25,7 +25,7 @@ func TestHandlerHeloRun(t *testing.T) {
 		receivedMessage := configuration.msgHeloReceived
 		handler := newHandlerHelo(session, message, configuration)
 		session.On("clearError").Once().Return(nil)
-		session.On("writeResponse", receivedMessage).Once().Return(nil)
+		session.On("writeResponse", receivedMessage, configuration.responseDelayHelo).Once().Return(nil)
 		handler.run(request)
 
 		assert.True(t, message.helo)
@@ -41,7 +41,7 @@ func TestHandlerHeloRun(t *testing.T) {
 		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
 		session.On("clearError").Once().Return(nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.helo)
@@ -60,7 +60,7 @@ func TestHandlerHeloRun(t *testing.T) {
 		session.On("clearError").Once().Return(nil)
 		session.On("readRequest").Once().Return(request, nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.helo)
@@ -93,7 +93,7 @@ func TestHandlerHeloWriteResult(t *testing.T) {
 	t.Run("when successful request received", func(t *testing.T) {
 		message := new(message)
 		handler := newHandlerHelo(session, message, configuration)
-		session.On("writeResponse", response).Once().Return(nil)
+		session.On("writeResponse", response, configuration.responseDelayHelo).Once().Return(nil)
 
 		assert.True(t, handler.writeResult(true, request, response))
 		assert.True(t, message.helo)
@@ -105,7 +105,7 @@ func TestHandlerHeloWriteResult(t *testing.T) {
 		message, err := new(message), errors.New(response)
 		handler := newHandlerHelo(session, message, configuration)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", response).Once().Return(nil)
+		session.On("writeResponse", response, configuration.responseDelayHelo).Once().Return(nil)
 
 		assert.True(t, handler.writeResult(false, request, response))
 		assert.False(t, message.helo)
@@ -121,7 +121,7 @@ func TestHandlerHeloIsInvalidCmdArg(t *testing.T) {
 		request, message, errorMessage := "HELO name.zone42", new(message), configuration.msgInvalidCmdHeloArg
 		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidCmdArg(request))
 		assert.False(t, message.helo)
@@ -172,7 +172,7 @@ func TestHandlerHeloIsBlacklistedDomain(t *testing.T) {
 		errorMessage := configuration.msgHeloBlacklistedDomain
 		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
 
 		assert.True(t, handler.isBlacklistedDomain(request))
 		assert.False(t, message.helo)
@@ -199,7 +199,7 @@ func TestHandlerHeloIsInvalidRequest(t *testing.T) {
 		session, message, errorMessage := new(sessionMock), new(message), configuration.msgInvalidCmdHeloArg
 		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidRequest(request))
 		assert.False(t, message.helo)
@@ -230,7 +230,7 @@ func TestHandlerHeloIsInvalidRequest(t *testing.T) {
 			configuration.blacklistedHeloDomains = heloDomains
 			handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
 			session.On("addError", err).Once().Return(nil)
-			session.On("writeResponse", errorMessage).Once().Return(nil)
+			session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
 
 			assert.True(t, handler.isInvalidRequest(request))
 			assert.False(t, message.helo)

--- a/handler_mailfrom.go
+++ b/handler_mailfrom.go
@@ -46,7 +46,7 @@ func (handler *handlerMailfrom) writeResult(isSuccessful bool, request, response
 	}
 
 	message.mailfromRequest, message.mailfromResponse, message.mailfrom = request, response, isSuccessful
-	session.writeResponse(response)
+	session.writeResponse(response, handler.configuration.responseDelayMailfrom)
 	return true
 }
 

--- a/handler_mailfrom_test.go
+++ b/handler_mailfrom_test.go
@@ -26,7 +26,7 @@ func TestHandlerMailfromRun(t *testing.T) {
 		message.helo = true
 		handler := newHandlerMailfrom(session, message, configuration)
 		session.On("clearError").Once().Return(nil)
-		session.On("writeResponse", receivedMessage).Once().Return(nil)
+		session.On("writeResponse", receivedMessage, configuration.responseDelayMailfrom).Once().Return(nil)
 		handler.run(request)
 
 		assert.True(t, message.mailfrom)
@@ -42,7 +42,7 @@ func TestHandlerMailfromRun(t *testing.T) {
 		handler, err := newHandlerMailfrom(session, message, configuration), errors.New(errorMessage)
 		session.On("clearError").Once().Return(nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayMailfrom).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.mailfrom)
@@ -59,7 +59,7 @@ func TestHandlerMailfromRun(t *testing.T) {
 		handler, err := newHandlerMailfrom(session, message, configuration), errors.New(errorMessage)
 		session.On("clearError").Once().Return(nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayMailfrom).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.mailfrom)
@@ -78,7 +78,7 @@ func TestHandlerMailfromRun(t *testing.T) {
 		session.On("clearError").Once().Return(nil)
 		session.On("readRequest").Once().Return(request, nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayMailfrom).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.mailfrom)
@@ -116,7 +116,7 @@ func TestHandlerMailfromWriteResult(t *testing.T) {
 	t.Run("when successful request received", func(t *testing.T) {
 		message := new(message)
 		handler := newHandlerMailfrom(session, message, configuration)
-		session.On("writeResponse", response).Once().Return(nil)
+		session.On("writeResponse", response, configuration.responseDelayMailfrom).Once().Return(nil)
 
 		assert.True(t, handler.writeResult(true, request, response))
 		assert.True(t, message.mailfrom)
@@ -128,7 +128,7 @@ func TestHandlerMailfromWriteResult(t *testing.T) {
 		message, err := new(message), errors.New(response)
 		handler := newHandlerMailfrom(session, message, configuration)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", response).Once().Return(nil)
+		session.On("writeResponse", response, configuration.responseDelayMailfrom).Once().Return(nil)
 
 		assert.True(t, handler.writeResult(false, request, response))
 		assert.False(t, message.mailfrom)
@@ -144,7 +144,7 @@ func TestHandlerMailfromIsInvalidCmdSequence(t *testing.T) {
 		message, errorMessage := new(message), configuration.msgInvalidCmdMailfromSequence
 		handler, err := newHandlerMailfrom(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayMailfrom).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidCmdSequence(request))
 		assert.False(t, message.mailfrom)
@@ -171,7 +171,7 @@ func TestHandlerMaifromIsInvalidCmdArg(t *testing.T) {
 		request, message, errorMessage := "MAIL FROM: email@invalid", new(message), configuration.msgInvalidCmdMailfromArg
 		handler, err := newHandlerMailfrom(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayMailfrom).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidCmdArg(request))
 		assert.False(t, message.mailfrom)
@@ -252,7 +252,7 @@ func TestHandlerHeloIsBlacklistedEmail(t *testing.T) {
 		errorMessage := configuration.msgMailfromBlacklistedEmail
 		handler, err := newHandlerMailfrom(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayMailfrom).Once().Return(nil)
 
 		assert.True(t, handler.isBlacklistedEmail(request))
 		assert.False(t, message.mailfrom)
@@ -279,7 +279,7 @@ func TestHandlerMailfromIsInvalidRequest(t *testing.T) {
 		session, message, errorMessage := new(sessionMock), new(message), configuration.msgInvalidCmdMailfromSequence
 		handler, err := newHandlerMailfrom(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayMailfrom).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidRequest(request))
 		assert.False(t, message.mailfrom)
@@ -293,7 +293,7 @@ func TestHandlerMailfromIsInvalidRequest(t *testing.T) {
 		message.helo = true
 		handler, err := newHandlerMailfrom(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayMailfrom).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidRequest(request))
 		assert.False(t, message.mailfrom)
@@ -308,7 +308,7 @@ func TestHandlerMailfromIsInvalidRequest(t *testing.T) {
 		configuration.blacklistedMailfromEmails, message.helo = []string{blacklistedEmail}, true
 		handler, err := newHandlerMailfrom(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayMailfrom).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidRequest(request))
 		assert.False(t, message.mailfrom)

--- a/handler_message.go
+++ b/handler_message.go
@@ -65,6 +65,6 @@ func (handler *handlerMessage) writeResult(isSuccessful bool, request, response 
 	}
 
 	message.msgRequest, message.msgResponse, message.msg = request, response, isSuccessful
-	session.writeResponse(response)
+	session.writeResponse(response, handler.configuration.responseDelayMessage)
 	return true
 }

--- a/handler_message_test.go
+++ b/handler_message_test.go
@@ -39,7 +39,7 @@ func TestHandlerMessageRun(t *testing.T) {
 		session.On("readBytes").Once().Return([]uint8(".\r\n"), nil)
 		session.On("discardBufin").Once().Return(nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayMessage).Once().Return(nil)
 		handler.run()
 
 		assert.False(t, message.msg)
@@ -52,7 +52,7 @@ func TestHandlerMessageRun(t *testing.T) {
 		handler, msgContext := newHandlerMessage(session, message, configuration), "some message"
 		session.On("readBytes").Once().Return([]uint8("."+msgContext), nil)
 		session.On("readBytes").Once().Return([]uint8(".\r\n"), nil)
-		session.On("writeResponse", defaultReceivedMsg).Once().Return(nil)
+		session.On("writeResponse", defaultReceivedMsg, configuration.responseDelayMessage).Once().Return(nil)
 		handler.run()
 
 		assert.True(t, message.msg)
@@ -68,7 +68,7 @@ func TestHandlerMessageWriteResult(t *testing.T) {
 	t.Run("when successful request received", func(t *testing.T) {
 		message := new(message)
 		handler := newHandlerMessage(session, message, configuration)
-		session.On("writeResponse", response).Once().Return(nil)
+		session.On("writeResponse", response, configuration.responseDelayMessage).Once().Return(nil)
 
 		assert.True(t, handler.writeResult(true, request, response))
 		assert.True(t, message.msg)
@@ -80,7 +80,7 @@ func TestHandlerMessageWriteResult(t *testing.T) {
 		message, err := new(message), errors.New(response)
 		handler := newHandlerMessage(session, message, configuration)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", response).Once().Return(nil)
+		session.On("writeResponse", response, configuration.responseDelayMessage).Once().Return(nil)
 
 		assert.True(t, handler.writeResult(false, request, response))
 		assert.False(t, message.msg)

--- a/handler_quit.go
+++ b/handler_quit.go
@@ -19,7 +19,8 @@ func (handler *handlerQuit) run(request string) {
 	}
 
 	handler.message.quitSent = true
-	handler.session.writeResponse(handler.configuration.msgQuitCmd)
+	configuration := handler.configuration
+	handler.session.writeResponse(configuration.msgQuitCmd, configuration.responseDelayQuit)
 }
 
 // Invalid QUIT command predicate. Returns true when request is invalid,

--- a/handler_quit_test.go
+++ b/handler_quit_test.go
@@ -22,7 +22,7 @@ func TestHandlerQuitRun(t *testing.T) {
 		request, session, message, configuration := "QUIT", new(sessionMock), new(message), createConfiguration()
 		receivedMessage := configuration.msgQuitCmd
 		handler := newHandlerQuit(session, message, configuration)
-		session.On("writeResponse", receivedMessage).Once().Return(nil)
+		session.On("writeResponse", receivedMessage, configuration.responseDelayQuit).Once().Return(nil)
 		handler.run(request)
 
 		assert.True(t, message.quitSent)

--- a/handler_rcptto.go
+++ b/handler_rcptto.go
@@ -49,7 +49,7 @@ func (handler *handlerRcptto) writeResult(isSuccessful bool, request, response s
 	}
 
 	message.rcpttoRequest, message.rcpttoResponse, message.rcptto = request, response, isSuccessful
-	session.writeResponse(response)
+	session.writeResponse(response, handler.configuration.responseDelayRcptto)
 	return true
 }
 

--- a/handler_rcptto_test.go
+++ b/handler_rcptto_test.go
@@ -26,7 +26,7 @@ func TestHandlerRcpttoRun(t *testing.T) {
 		message.helo, message.mailfrom = true, true
 		handler := newHandlerRcptto(session, message, configuration)
 		session.On("clearError").Once().Return(nil)
-		session.On("writeResponse", receivedMessage).Once().Return(nil)
+		session.On("writeResponse", receivedMessage, configuration.responseDelayRcptto).Once().Return(nil)
 		handler.run(request)
 
 		assert.True(t, message.rcptto)
@@ -42,7 +42,7 @@ func TestHandlerRcpttoRun(t *testing.T) {
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("clearError").Once().Return(nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.rcptto)
@@ -59,7 +59,7 @@ func TestHandlerRcpttoRun(t *testing.T) {
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("clearError").Once().Return(nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.rcptto)
@@ -78,7 +78,7 @@ func TestHandlerRcpttoRun(t *testing.T) {
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("clearError").Once().Return(nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.rcptto)
@@ -97,7 +97,7 @@ func TestHandlerRcpttoRun(t *testing.T) {
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("clearError").Once().Return(nil)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 		handler.run(request)
 
 		assert.False(t, message.rcptto)
@@ -138,7 +138,7 @@ func TestHandlerRcpttoWriteResult(t *testing.T) {
 	t.Run("when successful request received", func(t *testing.T) {
 		message := new(message)
 		handler := newHandlerRcptto(session, message, configuration)
-		session.On("writeResponse", response).Once().Return(nil)
+		session.On("writeResponse", response, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.writeResult(true, request, response))
 		assert.True(t, message.rcptto)
@@ -150,7 +150,7 @@ func TestHandlerRcpttoWriteResult(t *testing.T) {
 		message, err := new(message), errors.New(response)
 		handler := newHandlerRcptto(session, message, configuration)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", response).Once().Return(nil)
+		session.On("writeResponse", response, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.writeResult(false, request, response))
 		assert.False(t, message.rcptto)
@@ -166,7 +166,7 @@ func TestHandlerRcpttoIsInvalidCmdSequence(t *testing.T) {
 		message, errorMessage := new(message), configuration.msgInvalidCmdRcpttoSequence
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidCmdSequence(request))
 		assert.False(t, message.rcptto)
@@ -179,7 +179,7 @@ func TestHandlerRcpttoIsInvalidCmdSequence(t *testing.T) {
 		message.helo = true
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidCmdSequence(request))
 		assert.False(t, message.rcptto)
@@ -206,7 +206,7 @@ func TestHandlerRcpttoIsInvalidCmdArg(t *testing.T) {
 		request, message, errorMessage := "RCPT TO: email@invalid", new(message), configuration.msgInvalidCmdRcpttoArg
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidCmdArg(request))
 		assert.False(t, message.rcptto)
@@ -287,7 +287,7 @@ func TestHandlerRcpttoIsBlacklistedEmail(t *testing.T) {
 		errorMessage := configuration.msgRcpttoBlacklistedEmail
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.isBlacklistedEmail(request))
 		assert.False(t, message.rcptto)
@@ -316,7 +316,7 @@ func TestHandlerRcpttoIsNotRegisteredEmail(t *testing.T) {
 		errorMessage := configuration.msgRcpttoNotRegisteredEmail
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.isNotRegisteredEmail(request))
 		assert.False(t, message.rcptto)
@@ -343,7 +343,7 @@ func TestHandlerRcpttoIsInvalidRequest(t *testing.T) {
 		session, message, errorMessage := new(sessionMock), new(message), configuration.msgInvalidCmdRcpttoSequence
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidRequest(request))
 		assert.False(t, message.rcptto)
@@ -357,7 +357,7 @@ func TestHandlerRcpttoIsInvalidRequest(t *testing.T) {
 		message.helo, message.mailfrom = true, true
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidRequest(request))
 		assert.False(t, message.rcptto)
@@ -373,7 +373,7 @@ func TestHandlerRcpttoIsInvalidRequest(t *testing.T) {
 		message.helo, message.mailfrom = true, true
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidRequest(request))
 		assert.False(t, message.rcptto)
@@ -389,7 +389,7 @@ func TestHandlerRcpttoIsInvalidRequest(t *testing.T) {
 		message.helo, message.mailfrom = true, true
 		handler, err := newHandlerRcptto(session, message, configuration), errors.New(errorMessage)
 		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayRcptto).Once().Return(nil)
 
 		assert.True(t, handler.isInvalidRequest(request))
 		assert.False(t, message.rcptto)

--- a/server.go
+++ b/server.go
@@ -148,7 +148,7 @@ func (server *Server) removeFromWaitGroup() {
 func (server *Server) handleSession(session sessionInterface) {
 	defer session.finish()
 	message, configuration := server.newMessage(), server.configuration
-	session.writeResponse(configuration.msgGreeting)
+	session.writeResponse(configuration.msgGreeting, defaultSessionResponseDelay)
 
 	for {
 		select {
@@ -162,7 +162,7 @@ func (server *Server) handleSession(session sessionInterface) {
 			}
 
 			if server.isInvalidCmd(request) {
-				session.writeResponse(configuration.msgInvalidCmd)
+				session.writeResponse(configuration.msgInvalidCmd, defaultSessionResponseDelay)
 				continue
 			}
 

--- a/server_test.go
+++ b/server_test.go
@@ -84,45 +84,45 @@ func TestServerHandleSession(t *testing.T) {
 		session, configuration := &sessionMock{}, createConfiguration()
 		server := newServer(configuration)
 
-		session.On("writeResponse", configuration.msgGreeting).Once().Return(nil)
+		session.On("writeResponse", configuration.msgGreeting, defaultSessionResponseDelay).Once().Return(nil)
 
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return("helo example.com", nil)
 		session.On("clearError").Once().Return(nil)
-		session.On("writeResponse", configuration.msgHeloReceived).Once().Return(nil)
+		session.On("writeResponse", configuration.msgHeloReceived, configuration.responseDelayHelo).Once().Return(nil)
 		session.On("isErrorFound").Once().Return(false)
 
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return("ehlo example.com", nil)
 		session.On("clearError").Once().Return(nil)
-		session.On("writeResponse", configuration.msgHeloReceived).Once().Return(nil)
+		session.On("writeResponse", configuration.msgHeloReceived, configuration.responseDelayHelo).Once().Return(nil)
 		session.On("isErrorFound").Once().Return(false)
 
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return("mail from: receiver@example.com", nil)
 		session.On("clearError").Once().Return(nil)
-		session.On("writeResponse", configuration.msgMailfromReceived).Once().Return(nil)
+		session.On("writeResponse", configuration.msgMailfromReceived, configuration.responseDelayMailfrom).Once().Return(nil)
 		session.On("isErrorFound").Once().Return(false)
 
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return("rcpt to: sender@example.com", nil)
 		session.On("clearError").Once().Return(nil)
-		session.On("writeResponse", configuration.msgRcpttoReceived).Once().Return(nil)
+		session.On("writeResponse", configuration.msgRcpttoReceived, configuration.responseDelayRcptto).Once().Return(nil)
 		session.On("isErrorFound").Once().Return(false)
 
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return("data", nil)
 		session.On("clearError").Once().Return(nil)
-		session.On("writeResponse", configuration.msgDataReceived).Once().Return(nil)
+		session.On("writeResponse", configuration.msgDataReceived, configuration.responseDelayData).Once().Return(nil)
 		session.On("isErrorFound").Once().Return(false)
 
 		session.On("readBytes").Once().Return([]uint8(".some message"), nil)
 		session.On("readBytes").Once().Return([]uint8(".\r\n"), nil)
-		session.On("writeResponse", configuration.msgMsgReceived).Once().Return(nil)
+		session.On("writeResponse", configuration.msgMsgReceived, configuration.responseDelayMessage).Once().Return(nil)
 
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return("quit", nil)
-		session.On("writeResponse", configuration.msgQuitCmd).Once().Return(nil)
+		session.On("writeResponse", configuration.msgQuitCmd, configuration.responseDelayQuit).Once().Return(nil)
 		session.On("isErrorFound").Once().Return(false)
 
 		session.On("finish").Once().Return(nil)
@@ -134,15 +134,15 @@ func TestServerHandleSession(t *testing.T) {
 		session, configuration := &sessionMock{}, createConfiguration()
 		server := newServer(configuration)
 
-		session.On("writeResponse", configuration.msgGreeting).Once().Return(nil)
+		session.On("writeResponse", configuration.msgGreeting, defaultSessionResponseDelay).Once().Return(nil)
 
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return("not implemented command", nil)
-		session.On("writeResponse", configuration.msgInvalidCmd).Once().Return(nil)
+		session.On("writeResponse", configuration.msgInvalidCmd, defaultSessionResponseDelay).Once().Return(nil)
 
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return("quit", nil)
-		session.On("writeResponse", configuration.msgQuitCmd).Once().Return(nil)
+		session.On("writeResponse", configuration.msgQuitCmd, configuration.responseDelayQuit).Once().Return(nil)
 
 		session.On("finish").Once().Return(nil)
 
@@ -153,17 +153,17 @@ func TestServerHandleSession(t *testing.T) {
 		session, configuration := &sessionMock{}, newConfiguration(ConfigurationAttr{IsCmdFailFast: true})
 		server, errorMessage := newServer(configuration), configuration.msgInvalidCmdHeloArg
 
-		session.On("writeResponse", configuration.msgGreeting).Once().Return(nil)
+		session.On("writeResponse", configuration.msgGreeting, defaultSessionResponseDelay).Once().Return(nil)
 
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return("not implemented command", nil)
-		session.On("writeResponse", configuration.msgInvalidCmd).Once().Return(nil)
+		session.On("writeResponse", configuration.msgInvalidCmd, defaultSessionResponseDelay).Once().Return(nil)
 
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return("helo 42", nil)
 		session.On("clearError").Once().Return(nil)
 		session.On("addError", errors.New(errorMessage)).Once().Return(nil)
-		session.On("writeResponse", errorMessage).Once().Return(nil)
+		session.On("writeResponse", errorMessage, defaultSessionResponseDelay).Once().Return(nil)
 
 		session.On("isErrorFound").Once().Return(true)
 		session.On("finish").Once().Return(nil)
@@ -177,7 +177,7 @@ func TestServerHandleSession(t *testing.T) {
 		server.quit = make(chan interface{})
 		close(server.quit)
 
-		session.On("writeResponse", configuration.msgGreeting).Once().Return(nil)
+		session.On("writeResponse", configuration.msgGreeting, defaultSessionResponseDelay).Once().Return(nil)
 		session.On("finish").Once().Return(nil)
 
 		server.handleSession(session)
@@ -187,7 +187,7 @@ func TestServerHandleSession(t *testing.T) {
 		session, configuration := &sessionMock{}, newConfiguration(ConfigurationAttr{IsCmdFailFast: true})
 		server := newServer(configuration)
 
-		session.On("writeResponse", configuration.msgGreeting).Once().Return(nil)
+		session.On("writeResponse", configuration.msgGreeting, defaultSessionResponseDelay).Once().Return(nil)
 		session.On("setTimeout", defaultSessionTimeout).Once().Return(nil)
 		session.On("readRequest").Once().Return(emptyString, errors.New("some read request error"))
 		session.On("finish").Once().Return(nil)

--- a/test_mocks_test.go
+++ b/test_mocks_test.go
@@ -144,8 +144,8 @@ func (session *sessionMock) readRequest() (string, error) {
 	return args.String(0), args.Error(1)
 }
 
-func (session *sessionMock) writeResponse(response string) {
-	session.Called(response)
+func (session *sessionMock) writeResponse(response string, responseDelay int) {
+	session.Called(response, responseDelay)
 }
 
 func (session *sessionMock) addError(err error) {


### PR DESCRIPTION
- [x] Ability to specify session response delay for each SMTP command
- [x] Updated `configuration`, `ConfigurationAttr` tests
- [x] Updated consts
- [x] Updated `session` structure methods, tests
- [x] Updated `server#handleSession`, tests
- [x] Updated `handlerHelo#writeResult`, tests
- [x] Updated `handlerMailfrom#writeResult`, tests
- [x] Updated `handlerRcptto#writeResult`, tests
- [x] Updated `handlerData#writeResult`, tests
- [x] Updated `handlerMessage#writeResult`, tests
- [x] Updated `handlerQuit#writeResult`, tests
- [x] Updated `main.attrFromCommandLine()`, tests
- [x] Updated package documentation, changelog