### PR TITLE
Develop

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -16,6 +16,7 @@ type configuration struct {
 	msgInvalidCmdHeloArg          string
 	msgHeloBlacklistedDomain      string
 	msgHeloReceived               string
+	msgRsetReceived               string
 	msgInvalidCmdMailfromSequence string
 	msgInvalidCmdMailfromArg      string
 	msgMailfromBlacklistedEmail   string
@@ -39,6 +40,7 @@ type configuration struct {
 	responseDelayData             int
 	responseDelayMessage          int
 	responseDelayQuit             int
+	responseDelayRset             int
 	msgSizeLimit                  int
 	sessionTimeout                int
 	shutdownTimeout               int
@@ -75,6 +77,7 @@ func newConfiguration(config ConfigurationAttr) *configuration {
 		msgDataReceived:               config.MsgDataReceived,
 		msgMsgSizeIsTooBig:            config.MsgMsgSizeIsTooBig,
 		msgMsgReceived:                config.MsgMsgReceived,
+		msgRsetReceived:               config.MsgRsetReceived,
 		msgQuitCmd:                    config.MsgQuitCmd,
 		blacklistedHeloDomains:        config.BlacklistedHeloDomains,
 		blacklistedMailfromEmails:     config.BlacklistedMailfromEmails,
@@ -115,6 +118,7 @@ type ConfigurationAttr struct {
 	MsgRcpttoNotRegisteredEmail   string
 	MsgRcpttoBlacklistedEmail     string
 	MsgRcpttoReceived             string
+	MsgRsetReceived               string
 	MsgInvalidCmdDataSequence     string
 	MsgDataReceived               string
 	MsgMsgSizeIsTooBig            string
@@ -155,6 +159,9 @@ func (config *ConfigurationAttr) assignServerDefaultValues() {
 	}
 	if config.ShutdownTimeout == 0 {
 		config.ShutdownTimeout = defaultShutdownTimeout
+	}
+	if config.MsgRsetReceived == emptyString {
+		config.MsgRsetReceived = defaultRsetMsg
 	}
 }
 

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -39,6 +39,7 @@ func TestNewConfiguration(t *testing.T) {
 
 		assert.Equal(t, defaultInvalidCmdDataSequenceMsg, buildedConfiguration.msgInvalidCmdDataSequence)
 		assert.Equal(t, defaultReadyForReceiveMsg, buildedConfiguration.msgDataReceived)
+		assert.Equal(t, defaultRsetMsg, buildedConfiguration.msgRsetReceived)
 
 		assert.Equal(t, fmt.Sprintf(defaultMsgSizeIsTooBigMsg+" %d bytes", defaultMessageSizeLimit), buildedConfiguration.msgMsgSizeIsTooBig)
 		assert.Equal(t, defaultReceivedMsg, buildedConfiguration.msgMsgReceived)
@@ -80,6 +81,7 @@ func TestNewConfiguration(t *testing.T) {
 			MsgRcpttoNotRegisteredEmail:   "msgRcpttoNotRegisteredEmail",
 			MsgRcpttoBlacklistedEmail:     "msgRcpttoBlacklistedEmail",
 			MsgRcpttoReceived:             "msgRcpttoReceived",
+			MsgRsetReceived:               "msgRetReceived",
 			MsgInvalidCmdDataSequence:     "msgInvalidCmdDataSequence",
 			MsgDataReceived:               "msgDataReceived",
 			MsgMsgSizeIsTooBig:            emptyString,

--- a/consts.go
+++ b/consts.go
@@ -7,6 +7,7 @@ const (
 	defaultGreetingMsg                   = "220 Welcome"
 	defaultQuitMsg                       = "221 Closing connection"
 	defaultReceivedMsg                   = "250 Received"
+	defaultRsetMsg                       = "250 Ok"
 	defaultReadyForReceiveMsg            = "354 Ready for receive message. End data with <CR><LF>.<CR><LF>"
 	defaultTransientNegativeMsg          = "421 Service not available"
 	defaultInvalidCmdHeloArgMsg          = "501 HELO requires domain address"
@@ -50,7 +51,7 @@ const (
 	serverForceStopMsg               = "SMTP mock server was force stopped by timeout"
 
 	// Regex patterns
-	availableCmdsRegexPattern          = `(?i)helo|ehlo|mail from:|rcpt to:|data|quit`
+	availableCmdsRegexPattern          = `(?i)helo|ehlo|mail from:|rcpt to:|data|quit|rset`
 	domainRegexPattern                 = `(?i)([\p{L}0-9]+([\-.]{1}[\p{L}0-9]+)*\.\p{L}{2,63})`
 	emailRegexPattern                  = `(?i)<?((.+)@` + domainRegexPattern + `)>?`
 	validHeloCmdsRegexPattern          = `(?i)helo|ehlo`
@@ -58,6 +59,7 @@ const (
 	validRcpttoCmdRegexPattern         = `(?i)rcpt to:`
 	validDataCmdRegexPattern           = `\A(?i)data\z`
 	validQuitCmdRegexPattern           = `\A(?i)quit\z`
+	validRsetCmdsRegexPattern          = `(?i)rset\z`
 	validHeloComplexCmdRegexPattern    = `\A(` + validHeloCmdsRegexPattern + `) (` + domainRegexPattern + `|localhost)\z`
 	validMailromComplexCmdRegexPattern = `\A(` + validMailfromCmdRegexPattern + `) ?(` + emailRegexPattern + `)\z`
 	validRcpttoComplexCmdRegexPattern  = `\A(` + validRcpttoCmdRegexPattern + `) ?(` + emailRegexPattern + `)\z`

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/mocktools/go-smtp-mock
 go 1.15
 
 require (
+	github.com/go-test/deep v1.0.8 // indirect
 	github.com/stretchr/testify v1.7.1
+	github.com/xhit/go-simple-mail/v2 v2.11.0
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,17 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/toorop/go-dkim v0.0.0-20201103131630-e1cd1a0a5208 h1:PM5hJF7HVfNWmCjMdEfbuOBNXSVF2cMFGgQTPdKCbwM=
+github.com/toorop/go-dkim v0.0.0-20201103131630-e1cd1a0a5208/go.mod h1:BzWtXXrXzZUvMacR0oF/fbDDgUPO8L36tDMmRAf14ns=
+github.com/xhit/go-simple-mail/v2 v2.11.0 h1:o/056V50zfkO3Mm5tVdo9rG3ryg4ZmJ2XW5GMinHfVs=
+github.com/xhit/go-simple-mail/v2 v2.11.0/go.mod h1:b7P5ygho6SYE+VIqpxA6QkYfv4teeyG4MKqB3utRu98=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/handler_mailfrom.go
+++ b/handler_mailfrom.go
@@ -33,6 +33,7 @@ func (handler *handlerMailfrom) clearMessage() {
 		heloRequest:  messageWithData.heloRequest,
 		heloResponse: messageWithData.heloResponse,
 		helo:         messageWithData.helo,
+		rset:         messageWithData.rset,
 		cleared:      true,
 	}
 	*messageWithData = *clearedMessage
@@ -53,7 +54,7 @@ func (handler *handlerMailfrom) writeResult(isSuccessful bool, request, response
 // Invalid MAILFROM command sequence predicate. Returns true and writes result for case when
 // MAILFROM command sequence is invalid (HELO command was failure), otherwise returns false
 func (handler *handlerMailfrom) isInvalidCmdSequence(request string) bool {
-	if !handler.message.helo {
+	if !handler.message.helo && !handler.message.rset {
 		return handler.writeResult(false, request, handler.configuration.msgInvalidCmdMailfromSequence)
 	}
 

--- a/handler_rset.go
+++ b/handler_rset.go
@@ -1,0 +1,32 @@
+package smtpmock
+
+// RSET command handler
+type handlerRset struct {
+	*handler
+}
+
+// RSET command handler builder. Returns pointer to new handlerRset structure
+func newHandlerRset(session sessionInterface, message *message, configuration *configuration) *handlerRset {
+	return &handlerRset{&handler{session: session, message: message, configuration: configuration}}
+}
+
+// RSET handler methods
+
+// Main RSET handler runner
+func (handler *handlerRset) run(request string) {
+	if handler.isInvalidRequest(request) {
+		return
+	}
+	configuration := handler.configuration
+	handler.message.rset = true
+	handler.message.rsetRequest = request
+	handler.message.rsetResponse = configuration.msgRsetReceived
+
+	handler.session.writeResponse(configuration.msgRsetReceived, configuration.responseDelayRset)
+}
+
+// Invalid QUIT command predicate. Returns true when request is invalid,
+// otherwise returns false.
+func (handler *handlerRset) isInvalidRequest(request string) bool {
+	return !matchRegex(request, validRsetCmdsRegexPattern)
+}

--- a/handler_rset_test.go
+++ b/handler_rset_test.go
@@ -1,0 +1,37 @@
+package smtpmock
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewHandlerRset(t *testing.T) {
+	t.Run("returns new handlerRset", func(t *testing.T) {
+		session, message, configuration := new(session), new(message), new(configuration)
+		handler := newHandlerRset(session, message, configuration)
+
+		assert.Same(t, session, handler.session)
+		assert.Same(t, message, handler.message)
+		assert.Same(t, configuration, handler.configuration)
+	})
+}
+
+func TestHandlerRsetRun(t *testing.T) {
+	t.Run("when successful RSET request", func(t *testing.T) {
+		request, session, message, configuration := "RSET", new(sessionMock), new(message), createConfiguration()
+		receivedMessage := configuration.msgRsetReceived
+		handler := newHandlerRset(session, message, configuration)
+		session.On("writeResponse", receivedMessage, configuration.responseDelayRset).Once().Return(nil)
+		handler.run(request)
+
+		assert.True(t, message.rset)
+	})
+
+	t.Run("when failure RSET request", func(t *testing.T) {
+		request, session, message, configuration := "RSETbroken", new(sessionMock), new(message), createConfiguration()
+		handler := newHandlerRset(session, message, configuration)
+		handler.run(request)
+
+		assert.False(t, message.rset)
+	})
+}

--- a/message.go
+++ b/message.go
@@ -4,12 +4,13 @@ import "sync"
 
 // Structure for storing the result of SMTP client-server interaction
 type message struct {
-	heloRequest, heloResponse                            string
-	mailfromRequest, mailfromResponse                    string
-	rcpttoRequest, rcpttoResponse                        string
-	dataRequest, dataResponse                            string
-	msgRequest, msgResponse                              string
-	helo, mailfrom, rcptto, data, msg, cleared, quitSent bool
+	heloRequest, heloResponse                                  string
+	mailfromRequest, mailfromResponse                          string
+	rcpttoRequest, rcpttoResponse                              string
+	dataRequest, dataResponse                                  string
+	msgRequest, msgResponse                                    string
+	rsetRequest, rsetResponse                                  string
+	helo, mailfrom, rcptto, data, msg, cleared, quitSent, rset bool
 }
 
 // message methods
@@ -94,6 +95,16 @@ func (message *message) Msg() bool {
 // Getter for quitSent field
 func (message *message) QuitSent() bool {
 	return message.quitSent
+}
+
+// Getter for rsetRequest
+func (message *message) RsetRequest() string {
+	return message.rsetRequest
+}
+
+// Getter for rsetResponse
+func (message *message) RsetResponse() string {
+	return message.rsetResponse
 }
 
 // Cleared status predicate. Returns true for case when message struct

--- a/server.go
+++ b/server.go
@@ -176,6 +176,12 @@ func (server *Server) handleSession(session sessionInterface) {
 			case "HELO", "EHLO":
 				newHandlerHelo(session, message, configuration).run(request)
 			case "MAIL":
+				// If the previous command was RSET a new Message should be created
+				if message.rset {
+					message = server.newMessage()
+					message.rset = true
+					message.helo = true
+				}
 				newHandlerMailfrom(session, message, configuration).run(request)
 			case "RCPT":
 				newHandlerRcptto(session, message, configuration).run(request)
@@ -183,6 +189,8 @@ func (server *Server) handleSession(session sessionInterface) {
 				newHandlerData(session, message, configuration).run(request)
 			case "QUIT":
 				newHandlerQuit(session, message, configuration).run(request)
+			case "RSET":
+				newHandlerRset(session, message, configuration).run(request)
 			}
 
 			if message.quitSent || (session.isErrorFound() && configuration.isCmdFailFast) {

--- a/server_test.go
+++ b/server_test.go
@@ -321,8 +321,10 @@ func TestServerHandleRSET(t *testing.T) {
 		LogToStdout:       false,
 		LogServerActivity: false,
 	})
-	server.Start()
-
+	err := server.Start()
+	if err != nil {
+		t.Fatalf("error while starting the server: %s", err.Error())
+	}
 	srv := mail.NewSMTPClient()
 	srv.Host = "127.0.0.1"
 	srv.Port = server.PortNumber
@@ -341,15 +343,21 @@ func TestServerHandleRSET(t *testing.T) {
 			SetSubject("subject").
 			SetBody(mail.TextHTML, "HTML-body").
 			AddAlternative(mail.TextPlain, "TXT-alternative")
-		email.Send(client)
+		if err := email.Send(client); err != nil {
+			t.Fatalf("Error while sending email: %s", err.Error())
+		}
 
 		email.SetSubject("subject2")
 		email.SetFrom("sender2@test.com")
-		email.Send(client)
+		if err := email.Send(client); err != nil {
+			t.Fatalf("Error while sending email: %s", err.Error())
+		}
 
 		email.SetSubject("subject3")
 		email.SetFrom("sender3@test.com")
-		email.Send(client)
+		if err := email.Send(client); err != nil {
+			t.Fatalf("Error while sending email: %s", err.Error())
+		}
 
 		messages := server.Messages()
 		// there should be 3 messages


### PR DESCRIPTION
# PR Details
If multiple mails were sent via one connection
only the last one was returned when calling Server.Messages()

## Description
Added Handler for RSET

## Related Issue
https://github.com/mocktools/go-smtp-mock/issues/101

## How Has This Been Tested
See server_test.go:319

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/mocktools/go-smtp-mock/blob/master/CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] I have run `golangci-lint run` from the root directory to see all new and existing tests pass
- [x] I have run `go tool cover` to avoid test coverage degradation
