### PR TITLE
[FEATURE] Ability to use address literal as valid HELO command argument 

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -60,10 +60,11 @@ const (
 	validDataCmdRegexPattern           = `\A(?i)data\z`
 	validRsetCmdRegexPattern           = `\A(?i)rset\z`
 	validQuitCmdRegexPattern           = `\A(?i)quit\z`
-	validHeloComplexCmdRegexPattern    = `\A(` + validHeloCmdsRegexPattern + `) (` + domainRegexPattern + `|localhost|` + addressLiteralRegexPattern + `)\z`
+	validHeloComplexCmdRegexPattern    = `\A(` + validHeloCmdsRegexPattern + `) (` + domainRegexPattern + `|localhost|` + addressLiteralRegexPattern + `|` + ipAddressRegexPattern + `)\z`
 	validMailromComplexCmdRegexPattern = `\A(` + validMailfromCmdRegexPattern + `) ?(` + emailRegexPattern + `)\z`
 	validRcpttoComplexCmdRegexPattern  = `\A(` + validRcpttoCmdRegexPattern + `) ?(` + emailRegexPattern + `)\z`
-	addressLiteralRegexPattern         = `\[(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}\]`
+	ipAddressRegexPattern              = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
+	addressLiteralRegexPattern         = `\[` + ipAddressRegexPattern + `\]`
 
 	// Helpers
 	emptyString = ""

--- a/consts.go
+++ b/consts.go
@@ -10,7 +10,7 @@ const (
 	defaultReceivedMsg                   = "250 Received"
 	defaultReadyForReceiveMsg            = "354 Ready for receive message. End data with <CR><LF>.<CR><LF>"
 	defaultTransientNegativeMsg          = "421 Service not available"
-	defaultInvalidCmdHeloArgMsg          = "501 HELO requires domain address"
+	defaultInvalidCmdHeloArgMsg          = "501 HELO requires domain address or valid address literal"
 	defaultInvalidCmdMailfromArgMsg      = "501 MAIL FROM requires valid email address"
 	defaultInvalidCmdRcpttoArgMsg        = "501 RCPT TO requires valid email address"
 	defaultInvalidCmdMsg                 = "502 Command unrecognized. Available commands: HELO, EHLO, MAIL FROM:, RCPT TO:, DATA, RSET, QUIT"
@@ -60,9 +60,10 @@ const (
 	validDataCmdRegexPattern           = `\A(?i)data\z`
 	validRsetCmdRegexPattern           = `\A(?i)rset\z`
 	validQuitCmdRegexPattern           = `\A(?i)quit\z`
-	validHeloComplexCmdRegexPattern    = `\A(` + validHeloCmdsRegexPattern + `) (` + domainRegexPattern + `|localhost)\z`
+	validHeloComplexCmdRegexPattern    = `\A(` + validHeloCmdsRegexPattern + `) (` + domainRegexPattern + `|localhost|` + addressLiteralRegexPattern + `)\z`
 	validMailromComplexCmdRegexPattern = `\A(` + validMailfromCmdRegexPattern + `) ?(` + emailRegexPattern + `)\z`
 	validRcpttoComplexCmdRegexPattern  = `\A(` + validRcpttoCmdRegexPattern + `) ?(` + emailRegexPattern + `)\z`
+	addressLiteralRegexPattern         = `\[(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}\]`
 
 	// Helpers
 	emptyString = ""


### PR DESCRIPTION
Firstly, thank you for this unique project.
## Description

According to  [https://datatracker.ietf.org/doc/html/rfc2821#section-4.1.1.1](url) the mail client SHOULD send an address literal if the client system does not have a meaningful domain name.
The current version of go-smtp-mock only checks for a domain name.
The changes allow the client to send an address literal eg [192.168.1.1]
The ip address is validated via a regex alongside the domain validation.


## Related Issue

https://github.com/mocktools/go-smtp-mock/issues/112

## Motivation and Context

It will align the project with rfc2821


## How Has This Been Tested

Test included in test cases. 
Test for valid and invalid address literals

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/mocktools/go-smtp-mock/blob/master/CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] I have run `golangci-lint run` from the root directory to see all new and existing tests pass
- [x] I have run `go tool cover` to avoid test coverage degradation
