### PR TITLE
Feature/Ability to use address literal as valid HELO command argument

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -51,20 +51,21 @@ const (
 	serverForceStopMsg               = "SMTP mock server was force stopped by timeout"
 
 	// Regex patterns
-	availableCmdsRegexPattern          = `(?i)helo|ehlo|mail from:|rcpt to:|data|rset|quit`
-	domainRegexPattern                 = `(?i)([\p{L}0-9]+([\-.]{1}[\p{L}0-9]+)*\.\p{L}{2,63})`
-	emailRegexPattern                  = `(?i)<?((.+)@` + domainRegexPattern + `)>?`
+	availableCmdsRegexPattern  = `(?i)helo|ehlo|mail from:|rcpt to:|data|rset|quit`
+	domainRegexPattern         = `(?i)([\p{L}0-9]+([\-.]{1}[\p{L}0-9]+)*\.\p{L}{2,63})`
+	emailRegexPattern          = `(?i)<?((.+)@` + domainRegexPattern + `)>?`
+	ipAddressRegexPattern      = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
+	addressLiteralRegexPattern = `|\[` + ipAddressRegexPattern + `\]`
+
 	validHeloCmdsRegexPattern          = `(?i)helo|ehlo`
 	validMailfromCmdRegexPattern       = `(?i)mail from:`
 	validRcpttoCmdRegexPattern         = `(?i)rcpt to:`
 	validDataCmdRegexPattern           = `\A(?i)data\z`
 	validRsetCmdRegexPattern           = `\A(?i)rset\z`
 	validQuitCmdRegexPattern           = `\A(?i)quit\z`
-	validHeloComplexCmdRegexPattern    = `\A(` + validHeloCmdsRegexPattern + `) (` + domainRegexPattern + `|localhost|` + addressLiteralRegexPattern + `|` + ipAddressRegexPattern + `)\z`
+	validHeloComplexCmdRegexPattern    = `\A(` + validHeloCmdsRegexPattern + `) (` + domainRegexPattern + `|localhost|` + ipAddressRegexPattern + addressLiteralRegexPattern + `)\z`
 	validMailromComplexCmdRegexPattern = `\A(` + validMailfromCmdRegexPattern + `) ?(` + emailRegexPattern + `)\z`
 	validRcpttoComplexCmdRegexPattern  = `\A(` + validRcpttoCmdRegexPattern + `) ?(` + emailRegexPattern + `)\z`
-	ipAddressRegexPattern              = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
-	addressLiteralRegexPattern         = `\[` + ipAddressRegexPattern + `\]`
 
 	// Helpers
 	emptyString = ""

--- a/consts.go
+++ b/consts.go
@@ -10,7 +10,7 @@ const (
 	defaultReceivedMsg                   = "250 Received"
 	defaultReadyForReceiveMsg            = "354 Ready for receive message. End data with <CR><LF>.<CR><LF>"
 	defaultTransientNegativeMsg          = "421 Service not available"
-	defaultInvalidCmdHeloArgMsg          = "501 HELO requires domain address"
+	defaultInvalidCmdHeloArgMsg          = "501 HELO requires domain address or valid address literal"
 	defaultInvalidCmdMailfromArgMsg      = "501 MAIL FROM requires valid email address"
 	defaultInvalidCmdRcpttoArgMsg        = "501 RCPT TO requires valid email address"
 	defaultInvalidCmdMsg                 = "502 Command unrecognized. Available commands: HELO, EHLO, MAIL FROM:, RCPT TO:, DATA, RSET, QUIT"
@@ -60,9 +60,11 @@ const (
 	validDataCmdRegexPattern           = `\A(?i)data\z`
 	validRsetCmdRegexPattern           = `\A(?i)rset\z`
 	validQuitCmdRegexPattern           = `\A(?i)quit\z`
-	validHeloComplexCmdRegexPattern    = `\A(` + validHeloCmdsRegexPattern + `) (` + domainRegexPattern + `|localhost)\z`
+	validHeloComplexCmdRegexPattern    = `\A(` + validHeloCmdsRegexPattern + `) (` + domainRegexPattern + `|localhost|` + addressLiteralRegexPattern + `|` + ipAddressRegexPattern + `)\z`
 	validMailromComplexCmdRegexPattern = `\A(` + validMailfromCmdRegexPattern + `) ?(` + emailRegexPattern + `)\z`
 	validRcpttoComplexCmdRegexPattern  = `\A(` + validRcpttoCmdRegexPattern + `) ?(` + emailRegexPattern + `)\z`
+	ipAddressRegexPattern              = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
+	addressLiteralRegexPattern         = `\[` + ipAddressRegexPattern + `\]`
 
 	// Helpers
 	emptyString = ""

--- a/handler_helo_test.go
+++ b/handler_helo_test.go
@@ -19,7 +19,7 @@ func TestNewHandlerHelo(t *testing.T) {
 }
 
 func TestHandlerHeloRun(t *testing.T) {
-	t.Run("when successful HELO domain request", func(t *testing.T) {
+	t.Run("when successful HELO request", func(t *testing.T) {
 		request := "HELO example.com"
 		session, message, configuration := new(sessionMock), new(Message), createConfiguration()
 		receivedMessage := configuration.msgHeloReceived
@@ -31,35 +31,6 @@ func TestHandlerHeloRun(t *testing.T) {
 		assert.True(t, message.helo)
 		assert.Equal(t, request, message.heloRequest)
 		assert.Equal(t, receivedMessage, message.heloResponse)
-	})
-
-	t.Run("when successful HELO address literal request", func(t *testing.T) {
-		request := "HELO [192.168.8.1]"
-		session, message, configuration := new(sessionMock), new(Message), createConfiguration()
-		receivedMessage := configuration.msgHeloReceived
-		handler := newHandlerHelo(session, message, configuration)
-		session.On("clearError").Once().Return(nil)
-		session.On("writeResponse", receivedMessage, configuration.responseDelayHelo).Once().Return(nil)
-		handler.run(request)
-
-		assert.True(t, message.helo)
-		assert.Equal(t, request, message.heloRequest)
-		assert.Equal(t, receivedMessage, message.heloResponse)
-	})
-
-	t.Run("when failure HELO request, invalid address literal", func(t *testing.T) {
-		request := "HELO [999.999.999.999]"
-		session, message, configuration := new(sessionMock), new(Message), createConfiguration()
-		errorMessage := configuration.msgInvalidCmdHeloArg
-		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
-		session.On("clearError").Once().Return(nil)
-		session.On("addError", err).Once().Return(nil)
-		session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
-		handler.run(request)
-
-		assert.False(t, message.helo)
-		assert.Equal(t, request, message.heloRequest)
-		assert.Equal(t, errorMessage, message.heloResponse)
 	})
 
 	t.Run("when failure HELO request, invalid command argument", func(t *testing.T) {
@@ -164,6 +135,84 @@ func TestHandlerHeloIsInvalidCmdArg(t *testing.T) {
 		assert.Empty(t, message.heloRequest)
 		assert.Empty(t, message.heloResponse)
 	})
+
+	t.Run("when request includes localhost HELO argument", func(t *testing.T) {
+		message := new(Message)
+		handler := newHandlerHelo(session, message, configuration)
+
+		assert.False(t, handler.isInvalidCmdArg("HELO localhost"))
+		assert.False(t, message.helo)
+		assert.Empty(t, message.heloRequest)
+		assert.Empty(t, message.heloResponse)
+	})
+
+	t.Run("when request includes valid ip address HELO argument", func(t *testing.T) {
+		message := new(Message)
+		handler := newHandlerHelo(session, message, configuration)
+
+		assert.False(t, handler.isInvalidCmdArg("HELO 1.2.3.4"))
+		assert.False(t, message.helo)
+		assert.Empty(t, message.heloRequest)
+		assert.Empty(t, message.heloResponse)
+	})
+
+	t.Run("when request includes valid address literal HELO argument", func(t *testing.T) {
+		message := new(Message)
+		handler := newHandlerHelo(session, message, configuration)
+
+		assert.False(t, handler.isInvalidCmdArg("HELO [1.2.3.4]"))
+		assert.False(t, message.helo)
+		assert.Empty(t, message.heloRequest)
+		assert.Empty(t, message.heloResponse)
+	})
+
+	t.Run("when request includes invalid ip address HELO argument", func(t *testing.T) {
+		request, message, errorMessage := "HELO 999.999.999.999", new(Message), configuration.msgInvalidCmdHeloArg
+		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
+		session.On("addError", err).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
+
+		assert.True(t, handler.isInvalidCmdArg(request))
+		assert.False(t, message.helo)
+		assert.Equal(t, request, message.heloRequest)
+		assert.Equal(t, errorMessage, message.heloResponse)
+	})
+
+	t.Run("when request includes invalid address literal HELO argument", func(t *testing.T) {
+		request, message, errorMessage := "HELO [999.999.999.999]", new(Message), configuration.msgInvalidCmdHeloArg
+		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
+		session.On("addError", err).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
+
+		assert.True(t, handler.isInvalidCmdArg(request))
+		assert.False(t, message.helo)
+		assert.Equal(t, request, message.heloRequest)
+		assert.Equal(t, errorMessage, message.heloResponse)
+	})
+
+	t.Run("when request includes malformed (left) address literal HELO argument", func(t *testing.T) {
+		request, message, errorMessage := "HELO 1.2.3.4]", new(Message), configuration.msgInvalidCmdHeloArg
+		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
+		session.On("addError", err).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
+
+		assert.True(t, handler.isInvalidCmdArg(request))
+		assert.False(t, message.helo)
+		assert.Equal(t, request, message.heloRequest)
+		assert.Equal(t, errorMessage, message.heloResponse)
+	})
+
+	t.Run("when request includes malformed (right) address literal HELO argument", func(t *testing.T) {
+		request, message, errorMessage := "HELO [1.2.3.4", new(Message), configuration.msgInvalidCmdHeloArg
+		handler, err := newHandlerHelo(session, message, configuration), errors.New(errorMessage)
+		session.On("addError", err).Once().Return(nil)
+		session.On("writeResponse", errorMessage, configuration.responseDelayHelo).Once().Return(nil)
+
+		assert.True(t, handler.isInvalidCmdArg(request))
+		assert.False(t, message.helo)
+		assert.Equal(t, request, message.heloRequest)
+		assert.Equal(t, errorMessage, message.heloResponse)
+	})
 }
 
 func TestHandlerHeloHeloDomain(t *testing.T) {
@@ -233,7 +282,7 @@ func TestHandlerHeloIsInvalidRequest(t *testing.T) {
 		assert.Equal(t, errorMessage, message.heloResponse)
 	})
 
-	heloDomains := []string{"example.com", "localhost"}
+	heloDomains := []string{"example.com", "localhost", "1.2.3.4", "[1.2.3.4]"}
 
 	for _, heloDomain := range heloDomains {
 		t.Run("when valid HELO request", func(t *testing.T) {


### PR DESCRIPTION
Firstly, thank you for this unique project.
## Description

According to  [https://datatracker.ietf.org/doc/html/rfc2821#section-4.1.1.1](url) the mail client SHOULD send an address literal if the client system does not have a meaningful domain name.
The current version of go-smtp-mock only checks for a domain name.
The changes allow the client to send an address literal eg [192.168.1.1]
The ip address is validated via a regex alongside the domain validation.


## Related Issue

https://github.com/mocktools/go-smtp-mock/issues/112

## Motivation and Context

It will align the project with rfc2821


## How Has This Been Tested

Test included in test cases. 
Test for valid and invalid address literals

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/mocktools/go-smtp-mock/blob/master/CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] I have run `golangci-lint run` from the root directory to see all new and existing tests pass
- [x] I have run `go tool cover` to avoid test coverage degradation
