### PR TITLE
Bugfix/Fix Server Race Conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ func main() {
 
   // Server's port will be assigned dynamically after server.Start()
   // for case when portNumber wasn't specified
-  hostAddress, portNumber := "127.0.0.1", server.PortNumber
+  hostAddress, portNumber := "127.0.0.1", server.PortNumber()
 
   // Possible SMTP-client stuff for iteration with mock server
   address := fmt.Sprintf("%s:%d", hostAddress, portNumber)

--- a/message.go
+++ b/message.go
@@ -19,104 +19,104 @@ type Message struct {
 // message getters
 
 // Getter for heloRequest field
-func (message *Message) HeloRequest() string {
+func (message Message) HeloRequest() string {
 	return message.heloRequest
 }
 
 // Getter for heloResponse field
-func (message *Message) HeloResponse() string {
+func (message Message) HeloResponse() string {
 	return message.heloResponse
 }
 
 // Getter for helo field
-func (message *Message) Helo() bool {
+func (message Message) Helo() bool {
 	return message.helo
 }
 
 // Getter for mailfromRequest field
-func (message *Message) MailfromRequest() string {
+func (message Message) MailfromRequest() string {
 	return message.mailfromRequest
 }
 
 // Getter for mailfromResponse field
-func (message *Message) MailfromResponse() string {
+func (message Message) MailfromResponse() string {
 	return message.mailfromResponse
 }
 
 // Getter for mailfrom field
-func (message *Message) Mailfrom() bool {
+func (message Message) Mailfrom() bool {
 	return message.mailfrom
 }
 
 // Getter for rcpttoRequest field
-func (message *Message) RcpttoRequest() string {
+func (message Message) RcpttoRequest() string {
 	return message.rcpttoRequest
 }
 
 // Getter for rcpttoResponse field
-func (message *Message) RcpttoResponse() string {
+func (message Message) RcpttoResponse() string {
 	return message.rcpttoResponse
 }
 
 // Getter for rcptto field
-func (message *Message) Rcptto() bool {
+func (message Message) Rcptto() bool {
 	return message.rcptto
 }
 
 // Getter for dataRequest field
-func (message *Message) DataRequest() string {
+func (message Message) DataRequest() string {
 	return message.dataRequest
 }
 
 // Getter for dataResponse field
-func (message *Message) DataResponse() string {
+func (message Message) DataResponse() string {
 	return message.dataResponse
 }
 
 // Getter for data field
-func (message *Message) Data() bool {
+func (message Message) Data() bool {
 	return message.data
 }
 
 // Getter for msgRequest field
-func (message *Message) MsgRequest() string {
+func (message Message) MsgRequest() string {
 	return message.msgRequest
 }
 
 // Getter for msgResponse field
-func (message *Message) MsgResponse() string {
+func (message Message) MsgResponse() string {
 	return message.msgResponse
 }
 
 // Getter for msg field
-func (message *Message) Msg() bool {
+func (message Message) Msg() bool {
 	return message.msg
 }
 
 // Getter for rsetRequest field
-func (message *Message) RsetRequest() string {
+func (message Message) RsetRequest() string {
 	return message.rsetRequest
 }
 
 // Getter for rsetResponse field
-func (message *Message) RsetResponse() string {
+func (message Message) RsetResponse() string {
 	return message.rsetResponse
 }
 
 // Getter for rset field
-func (message *Message) Rset() bool {
+func (message Message) Rset() bool {
 	return message.rset
 }
 
 // Getter for quitSent field
-func (message *Message) QuitSent() bool {
+func (message Message) QuitSent() bool {
 	return message.quitSent
 }
 
 // Message consistency status predicate. Returns true for case when message struct is consistent.
 // It means that MAILFROM, RCPTTO, DATA commands and message context were successful.
 // Otherwise returns false
-func (message *Message) isConsistent() bool {
+func (message Message) isConsistent() bool {
 	return message.mailfrom && message.rcptto && message.data && message.msg
 }
 

--- a/message.go
+++ b/message.go
@@ -125,7 +125,7 @@ var zeroMessage = &Message{}
 
 // Concurrent type that can be safely shared between goroutines
 type messages struct {
-	sync.RWMutex
+	sync.Mutex
 	items []*Message
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -21,8 +21,8 @@ func TestNewServer(t *testing.T) {
 		assert.Nil(t, server.listener)
 		assert.NotNil(t, server.wg)
 		assert.Nil(t, server.quit)
-		assert.False(t, server.isStarted)
-		assert.Equal(t, 0, server.PortNumber)
+		assert.False(t, server.isStarted())
+		assert.Equal(t, 0, server.PortNumber())
 	})
 }
 
@@ -338,12 +338,12 @@ func TestServerStart(t *testing.T) {
 		server := newServer(configuration)
 
 		assert.NoError(t, server.Start())
-		_ = runSuccessfulSMTPSession(configuration.hostAddress, server.PortNumber, false)
+		_ = runSuccessfulSMTPSession(configuration.hostAddress, server.PortNumber(), false)
 		assert.NotEmpty(t, server.messages)
 		assert.NotNil(t, server.quit)
 		assert.NotNil(t, server.quitTimeout)
-		assert.True(t, server.isStarted)
-		assert.Greater(t, server.PortNumber, 0)
+		assert.True(t, server.isStarted())
+		assert.Greater(t, server.PortNumber(), 0)
 
 		_ = server.Stop()
 	})
@@ -358,17 +358,17 @@ func TestServerStart(t *testing.T) {
 		assert.NotEmpty(t, server.messages)
 		assert.NotNil(t, server.quit)
 		assert.NotNil(t, server.quitTimeout)
-		assert.True(t, server.isStarted)
-		assert.Equal(t, portNumber, server.PortNumber)
+		assert.True(t, server.isStarted())
+		assert.Equal(t, portNumber, server.PortNumber())
 
 		_ = server.Stop()
 	})
 
 	t.Run("when active server doesn't start current server", func(t *testing.T) {
-		server := &Server{isStarted: true}
+		server := &Server{started: true}
 
 		assert.EqualError(t, server.Start(), serverStartErrorMsg)
-		assert.Equal(t, 0, server.PortNumber)
+		assert.Equal(t, 0, server.PortNumber())
 	})
 
 	t.Run("when listener error happens during starting the server doesn't start current server", func(t *testing.T) {
@@ -381,8 +381,8 @@ func TestServerStart(t *testing.T) {
 		logger.On("error", errorMessage).Once().Return(nil)
 
 		assert.EqualError(t, server.Start(), errorMessage)
-		assert.False(t, server.isStarted)
-		assert.Equal(t, 0, server.PortNumber)
+		assert.False(t, server.isStarted())
+		assert.Equal(t, 0, server.PortNumber())
 		listener.Close()
 	})
 }
@@ -396,7 +396,7 @@ func TestServerStop(t *testing.T) {
 			listener:      listener,
 			wg:            waitGroup,
 			quit:          quitChannel,
-			isStarted:     true,
+			started:       true,
 			quitTimeout:   make(chan interface{}),
 		}
 		listener.On("Close").Once().Return(nil)
@@ -404,7 +404,7 @@ func TestServerStop(t *testing.T) {
 		logger.On("infoActivity", serverStopMsg).Once().Return(nil)
 
 		assert.NoError(t, server.Stop())
-		assert.False(t, server.isStarted)
+		assert.False(t, server.isStarted())
 		_, isChannelOpened := <-server.quit
 		assert.False(t, isChannelOpened)
 	})
@@ -417,14 +417,14 @@ func TestServerStop(t *testing.T) {
 			listener:      listener,
 			wg:            waitGroup,
 			quit:          quitChannel,
-			isStarted:     true,
+			started:       true,
 		}
 		listener.On("Close").Once().Return(nil)
 		waitGroup.On("Wait").Once().Return(nil)
 		logger.On("infoActivity", serverForceStopMsg).Once().Return(nil)
 
 		assert.NoError(t, server.Stop())
-		assert.False(t, server.isStarted)
+		assert.False(t, server.isStarted())
 		_, isChannelOpened := <-server.quit
 		assert.False(t, isChannelOpened)
 	})

--- a/smtpmock_test.go
+++ b/smtpmock_test.go
@@ -140,7 +140,7 @@ func TestNew(t *testing.T) {
 
 	t.Run("successful iteration with new server", func(t *testing.T) {
 		server := New(ConfigurationAttr{MultipleMessageReceiving: true})
-		configuration, messages := server.configuration, server.messages
+		configuration, messages := server.configuration, server.Messages()
 
 		assert.Empty(t, messages)
 		assert.NotNil(t, server.logger)
@@ -153,12 +153,12 @@ func TestNew(t *testing.T) {
 		_ = runSuccessfulSMTPSession(configuration.hostAddress, server.PortNumber(), true)
 		_ = server.Stop()
 
-		assert.Equal(t, 2, len(messages.items))
+		assert.Equal(t, 2, len(server.Messages()))
 		assert.NotNil(t, server.quit)
 		assert.False(t, server.isStarted())
 		assert.Greater(t, server.PortNumber(), 0)
 
-		receivedMessages := messages.items
+		receivedMessages := server.Messages()
 		firstMessage, secondMessage := receivedMessages[0], receivedMessages[1]
 
 		assert.True(t, firstMessage.helo)

--- a/smtpmock_test.go
+++ b/smtpmock_test.go
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 		assert.NotNil(t, server.logger)
 		assert.NotNil(t, server.wg)
 		assert.Nil(t, server.quit)
-		assert.False(t, server.isStarted)
+		assert.False(t, server.isStarted())
 	})
 
 	t.Run("creates new server with custom configuration settings", func(t *testing.T) {
@@ -135,7 +135,7 @@ func TestNew(t *testing.T) {
 		assert.NotNil(t, server.logger)
 		assert.NotNil(t, server.wg)
 		assert.Nil(t, server.quit)
-		assert.False(t, server.isStarted)
+		assert.False(t, server.isStarted())
 	})
 
 	t.Run("successful iteration with new server", func(t *testing.T) {
@@ -146,17 +146,17 @@ func TestNew(t *testing.T) {
 		assert.NotNil(t, server.logger)
 		assert.NotNil(t, server.wg)
 		assert.Nil(t, server.quit)
-		assert.False(t, server.isStarted)
+		assert.False(t, server.isStarted())
 
 		assert.NoError(t, server.Start())
-		assert.True(t, server.isStarted)
-		_ = runSuccessfulSMTPSession(configuration.hostAddress, server.PortNumber, true)
+		assert.True(t, server.isStarted())
+		_ = runSuccessfulSMTPSession(configuration.hostAddress, server.PortNumber(), true)
 		_ = server.Stop()
 
 		assert.Equal(t, 2, len(messages.items))
 		assert.NotNil(t, server.quit)
-		assert.False(t, server.isStarted)
-		assert.Greater(t, server.PortNumber, 0)
+		assert.False(t, server.isStarted())
+		assert.Greater(t, server.PortNumber(), 0)
 
 		receivedMessages := messages.items
 		firstMessage, secondMessage := receivedMessages[0], receivedMessages[1]


### PR DESCRIPTION
# Resolve race conditions with R/W lock in Server

## Description

Running the tests in this repo with the `-race` flag detects multiple race conditions.

First course of action is to add a `sync.Mutex` to the `Server` type, then replace direct reads and writes to `isStarted` and `PortNumber` fields with setter and getter methods which lock until it is safe to access these values. Unfortunately, to ensure safety, this necessitates a breaking change - the `PortNumber` field cannot be exposed any longer, so it is made a private field and users must call the `PortNumber()` method instead.

Secondly, it is not safe for the `Messages()` method to return a slice of pointers to Message data, this has been changed to return a copy of the data instead.

## Related Issue

https://github.com/mocktools/go-smtp-mock/issues/124

## Motivation and Context

Running the tests in this repo with the `-race` flag detects multiple race conditions. Changes solve this by using a lock to stop concurrent reads/writes in the `Server`.

## How Has This Been Tested

Cloned repo locally, ran `go test -race ./...`
Ran `golangci-lint` - no issues

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/mocktools/go-smtp-mock/blob/master/CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [x] I have run `golangci-lint run` from the root directory to see all new and existing tests pass
- [ ] I have run `go tool cover` to avoid test coverage degradation
