### PR TITLE
Feature/Ability to use multiple RCPT TO commands during one session

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   linters:
     docker:
-      - image: golangci/golangci-lint:v1.49-alpine
+      - image: golangci/golangci-lint:v1.50.1-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2022-11-14
+
+### Added
+
+- Added ability to use multiple `RCPT TO` commands during one SMTP session, following [RFC 2821](https://datatracker.ietf.org/doc/html/rfc2821#section-4.1.1.3) (section 4.1.1.3). Thanks [@dandare100](https://github.com/dandare100) for request and provided examples
+- Added `ConfigurationAttr#MultipleRcptto`, `configuration#multipleRcptto`, tests
+- Added `Message#rcpttoRequestResponse`, `Message#isIncludesSuccessfulRcpttoResponse()`, tests
+- Added `handlerRcptto#resolveMessageStatus()`, tests
+
+### Removed
+
+- Removed `Message#rcpttoRequest`, `Message#rcpttoResponse`
+
+### Updated
+
+- Updated `handlerRcptto#clearMessage()`, `handlerRcptto#writeResult()`, `handlerData#clearMessage()`, tests
+- Updated Go reference trigger script
+- Updated project documentation
+
 ## [1.10.0] - 2022-09-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ![SMTP mock server written on Golang. Mimic any SMTP server behaviour for your test environment with fake SMTP server](https://repository-images.githubusercontent.com/401721985/848bc1dd-fc35-4d78-8bd9-0ac3430270d8)
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/mocktools/go-smtp-mock)](https://goreportcard.com/report/github.com/mocktools/go-smtp-mock)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mocktools/go-smtp-mock/v2)](https://goreportcard.com/report/github.com/mocktools/go-smtp-mock/v2)
 [![Codecov](https://codecov.io/gh/mocktools/go-smtp-mock/branch/master/graph/badge.svg)](https://codecov.io/gh/mocktools/go-smtp-mock)
 [![CircleCI](https://circleci.com/gh/mocktools/go-smtp-mock/tree/master.svg?style=svg)](https://circleci.com/gh/mocktools/go-smtp-mock/tree/master)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/mocktools/go-smtp-mock)](https://github.com/mocktools/go-smtp-mock/releases)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/mocktools/go-smtp-mock)](https://pkg.go.dev/github.com/mocktools/go-smtp-mock)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/mocktools/go-smtp-mock/v2)](https://pkg.go.dev/github.com/mocktools/go-smtp-mock/v2)
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 [![GitHub](https://img.shields.io/github/license/mocktools/go-smtp-mock)](LICENSE.txt)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
@@ -42,6 +42,7 @@
 - Comes with default settings out of the box, configure only what you need
 - Ability to override previous SMTP commands
 - Fail fast scenario (ability to close client session for case when command was inconsistent or failed)
+- Multiple receivers (ability to configure multiple `RCPT TO` commands receiving during one session)
 - Multiple message receiving (ability to configure multiple message receiving during one session)
 - Mock-server activity logger
 - Ability to do graceful/force shutdown of SMTP mock server
@@ -60,8 +61,8 @@ Golang 1.15+
 Install `smtpmock`:
 
 ```bash
-go get github.com/mocktools/go-smtp-mock
-go install -i github.com/mocktools/go-smtp-mock
+go get github.com/mocktools/go-smtp-mock/v2
+go install -i github.com/mocktools/go-smtp-mock/v2/smtpmock@latest
 ```
 
 Import `smtpmock` dependency into your code:
@@ -69,7 +70,7 @@ Import `smtpmock` dependency into your code:
 ```go
 package main
 
-import "github.com/mocktools/go-smtp-mock"
+import "github.com/mocktools/go-smtp-mock/v2"
 ```
 
 ## Usage
@@ -125,9 +126,16 @@ smtpmock.ConfigurationAttr{
   // It's equal to false by default
   IsCmdFailFast:                 true,
 
+  // Ability to configure multiple RCPT TO command receiving during one session.
+  // It means that server will handle and save all RCPT TO command request-response
+  // pairs until receive succesful response and next SMTP command has been passed.
+  // Please note, by default will be saved only one, the last RCPT TO command
+  // request-response pair. It's equal to false by default
+  MultipleRcptto:                true,
+
   // Ability to configure multiple message receiving during one session. It means that server
   // will create another message during current SMTP session in case when RSET
-  // command has been used after succesful commands chain: MAILFROM, RCPTTO, DATA.
+  // command has been used after succesful commands chain: MAIL FROM, RCPT TO, DATA.
   // Please note, by default RSET command flushes current message in any case.
   // It's equal to false by default
   MultipleMessageReceiving:      true,
@@ -376,6 +384,7 @@ curl -sL https://raw.githubusercontent.com/mocktools/go-smtp-mock/master/script/
 | `-sessionTimeout` - session timeout in seconds. It's equal to 30 seconds by default | `-sessionTimeout=60` |
 | `-shutdownTimeout` - graceful shutdown timeout in seconds. It's equal to 1 second by default | `-shutdownTimeout=5` |
 | `-failFast` - enables fail fast scenario. Disabled by default | `-failFast` |
+| `-multipleRcptto` - enables multiple `RCPT TO` receiving scenario. Disabled by default | `-multipleRcptto` |
 | `-multipleMessageReceiving` - enables multiple message receiving scenario. Disabled by default | `-multipleMessageReceiving` |
 | `-blacklistedHeloDomains` - blacklisted `HELO` domains, separated by commas | `-blacklistedHeloDomains="example1.com,example2.com"` |
 | `-blacklistedMailfromEmails` - blacklisted `MAIL FROM` emails, separated by commas | `-blacklistedMailfromEmails="a@example1.com,b@example2.com"` |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"syscall"
 
-	smtpmock "github.com/mocktools/go-smtp-mock"
-	version "github.com/mocktools/go-smtp-mock/cmd/version"
+	smtpmock "github.com/mocktools/go-smtp-mock/v2"
+	version "github.com/mocktools/go-smtp-mock/v2/cmd/version"
 )
 
 const (
@@ -88,6 +88,7 @@ func attrFromCommandLine(args []string, options ...flag.ErrorHandling) (bool, *s
 		sessionTimeout                = flags.Int("sessionTimeout", 0, "Session timeout in seconds. It's equal to 30 seconds by default")
 		shutdownTimeout               = flags.Int("shutdownTimeout", 0, "Graceful shutdown timeout in seconds. It's equal to 1 second by default")
 		failFast                      = flags.Bool("failFast", false, "Enables fail fast scenario. Disabled by default")
+		multipleRcptto                = flags.Bool("multipleRcptto", false, "Enables multiple RCPT TO receiving scenario. Disabled by default")
 		multipleMessageReceiving      = flags.Bool("multipleMessageReceiving", false, "Enables multiple message receiving scenario. Disabled by default")
 		blacklistedHeloDomains        = flags.String("blacklistedHeloDomains", "", "Blacklisted HELO domains, separated by commas")
 		blacklistedMailfromEmails     = flags.String("blacklistedMailfromEmails", "", "Blacklisted MAIL FROM emails, separated by commas")
@@ -137,6 +138,7 @@ func attrFromCommandLine(args []string, options ...flag.ErrorHandling) (bool, *s
 		SessionTimeout:                *sessionTimeout,
 		ShutdownTimeout:               *shutdownTimeout,
 		IsCmdFailFast:                 *failFast,
+		MultipleRcptto:                *multipleRcptto,
 		MultipleMessageReceiving:      *multipleMessageReceiving,
 		BlacklistedHeloDomains:        toSlice(*blacklistedHeloDomains),
 		BlacklistedMailfromEmails:     toSlice(*blacklistedMailfromEmails),

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"testing"
 
-	version "github.com/mocktools/go-smtp-mock/cmd/version"
+	version "github.com/mocktools/go-smtp-mock/v2/cmd/version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -133,6 +133,7 @@ func TestAttrFromCommandLine(t *testing.T) {
 				"-sessionTimeout=" + strconv.Itoa(sessionTimeout),
 				"-shutdownTimeout=" + strconv.Itoa(shutdownTimeout),
 				"-failFast",
+				"-multipleRcptto",
 				"-multipleMessageReceiving",
 				"-blacklistedHeloDomains=" + blacklistedHeloDomains,
 				"-blacklistedMailfromEmails=" + blacklistedMailfromEmails,
@@ -178,6 +179,7 @@ func TestAttrFromCommandLine(t *testing.T) {
 		assert.Equal(t, sessionTimeout, configAttr.SessionTimeout)
 		assert.Equal(t, shutdownTimeout, configAttr.ShutdownTimeout)
 		assert.True(t, configAttr.IsCmdFailFast)
+		assert.True(t, configAttr.MultipleRcptto)
 		assert.True(t, configAttr.MultipleMessageReceiving)
 		assert.Equal(t, toSlice(blacklistedHeloDomains), configAttr.BlacklistedHeloDomains)
 		assert.Equal(t, toSlice(blacklistedMailfromEmails), configAttr.BlacklistedMailfromEmails)

--- a/configuration.go
+++ b/configuration.go
@@ -9,6 +9,7 @@ type configuration struct {
 	logToStdout                   bool
 	logServerActivity             bool
 	isCmdFailFast                 bool
+	multipleRcptto                bool
 	multipleMessageReceiving      bool
 	msgGreeting                   string
 	msgInvalidCmd                 string
@@ -61,6 +62,7 @@ func newConfiguration(config ConfigurationAttr) *configuration {
 		logToStdout:                   config.LogToStdout,
 		logServerActivity:             config.LogServerActivity,
 		isCmdFailFast:                 config.IsCmdFailFast,
+		multipleRcptto:                config.MultipleRcptto,
 		multipleMessageReceiving:      config.MultipleMessageReceiving,
 		msgGreeting:                   config.MsgGreeting,
 		msgInvalidCmd:                 config.MsgInvalidCmd,
@@ -109,6 +111,7 @@ type ConfigurationAttr struct {
 	LogToStdout                   bool
 	LogServerActivity             bool
 	IsCmdFailFast                 bool
+	MultipleRcptto                bool
 	MultipleMessageReceiving      bool
 	MsgGreeting                   string
 	MsgInvalidCmd                 string

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -14,6 +14,7 @@ func TestNewConfiguration(t *testing.T) {
 		assert.Equal(t, defaultHostAddress, buildedConfiguration.hostAddress)
 		assert.False(t, buildedConfiguration.logToStdout)
 		assert.False(t, buildedConfiguration.isCmdFailFast)
+		assert.False(t, buildedConfiguration.multipleRcptto)
 		assert.False(t, buildedConfiguration.multipleMessageReceiving)
 		assert.False(t, buildedConfiguration.logServerActivity)
 		assert.Equal(t, defaultGreetingMsg, buildedConfiguration.msgGreeting)
@@ -70,6 +71,7 @@ func TestNewConfiguration(t *testing.T) {
 			LogToStdout:                   true,
 			LogServerActivity:             true,
 			IsCmdFailFast:                 true,
+			MultipleRcptto:                true,
 			MultipleMessageReceiving:      true,
 			MsgGreeting:                   "msgGreeting",
 			MsgInvalidCmd:                 "msgInvalidCmd",
@@ -115,6 +117,7 @@ func TestNewConfiguration(t *testing.T) {
 		assert.Equal(t, configAttr.PortNumber, buildedConfiguration.portNumber)
 		assert.Equal(t, configAttr.LogToStdout, buildedConfiguration.logToStdout)
 		assert.Equal(t, configAttr.IsCmdFailFast, buildedConfiguration.isCmdFailFast)
+		assert.Equal(t, configAttr.MultipleRcptto, buildedConfiguration.multipleRcptto)
 		assert.Equal(t, configAttr.MultipleMessageReceiving, buildedConfiguration.multipleMessageReceiving)
 		assert.Equal(t, configAttr.LogServerActivity, buildedConfiguration.logServerActivity)
 		assert.Equal(t, configAttr.MsgGreeting, buildedConfiguration.msgGreeting)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mocktools/go-smtp-mock
+module github.com/mocktools/go-smtp-mock/v2
 
 go 1.15
 

--- a/handler_data.go
+++ b/handler_data.go
@@ -1,8 +1,6 @@
 package smtpmock
 
-import (
-	"errors"
-)
+import "errors"
 
 // DATA command handler
 type handlerData struct {
@@ -37,15 +35,14 @@ func (handler *handlerData) run(request string) {
 func (handler *handlerData) clearMessage() {
 	messageWithData := handler.message
 	clearedMessage := &Message{
-		heloRequest:      messageWithData.heloRequest,
-		heloResponse:     messageWithData.heloResponse,
-		helo:             messageWithData.helo,
-		mailfromRequest:  messageWithData.mailfromRequest,
-		mailfromResponse: messageWithData.mailfromResponse,
-		mailfrom:         messageWithData.mailfrom,
-		rcpttoRequest:    messageWithData.rcpttoRequest,
-		rcpttoResponse:   messageWithData.rcpttoResponse,
-		rcptto:           messageWithData.rcptto,
+		heloRequest:           messageWithData.heloRequest,
+		heloResponse:          messageWithData.heloResponse,
+		helo:                  messageWithData.helo,
+		mailfromRequest:       messageWithData.mailfromRequest,
+		mailfromResponse:      messageWithData.mailfromResponse,
+		mailfrom:              messageWithData.mailfrom,
+		rcpttoRequestResponse: messageWithData.rcpttoRequestResponse,
+		rcptto:                messageWithData.rcptto,
 	}
 	*messageWithData = *clearedMessage
 }

--- a/handler_data_test.go
+++ b/handler_data_test.go
@@ -73,15 +73,14 @@ func TestHandlerDataClearMessage(t *testing.T) {
 		notEmptyMessage := createNotEmptyMessage()
 		handler := newHandlerData(new(session), notEmptyMessage, new(configuration))
 		clearedMessage := &Message{
-			heloRequest:      notEmptyMessage.heloRequest,
-			heloResponse:     notEmptyMessage.heloResponse,
-			helo:             notEmptyMessage.helo,
-			mailfromRequest:  notEmptyMessage.mailfromRequest,
-			mailfromResponse: notEmptyMessage.mailfromResponse,
-			mailfrom:         notEmptyMessage.mailfrom,
-			rcpttoRequest:    notEmptyMessage.rcpttoRequest,
-			rcpttoResponse:   notEmptyMessage.rcpttoResponse,
-			rcptto:           notEmptyMessage.rcptto,
+			heloRequest:           notEmptyMessage.heloRequest,
+			heloResponse:          notEmptyMessage.heloResponse,
+			helo:                  notEmptyMessage.helo,
+			mailfromRequest:       notEmptyMessage.mailfromRequest,
+			mailfromResponse:      notEmptyMessage.mailfromResponse,
+			mailfrom:              notEmptyMessage.mailfrom,
+			rcpttoRequestResponse: notEmptyMessage.rcpttoRequestResponse,
+			rcptto:                notEmptyMessage.rcptto,
 		}
 		handler.clearMessage()
 

--- a/message.go
+++ b/message.go
@@ -7,7 +7,7 @@ import "sync"
 type Message struct {
 	heloRequest, heloResponse                         string
 	mailfromRequest, mailfromResponse                 string
-	rcpttoRequest, rcpttoResponse                     string
+	rcpttoRequestResponse                             [][]string
 	dataRequest, dataResponse                         string
 	msgRequest, msgResponse                           string
 	rsetRequest, rsetResponse                         string
@@ -48,14 +48,9 @@ func (message *Message) Mailfrom() bool {
 	return message.mailfrom
 }
 
-// Getter for rcpttoRequest field
-func (message *Message) RcpttoRequest() string {
-	return message.rcpttoRequest
-}
-
-// Getter for rcpttoResponse field
-func (message *Message) RcpttoResponse() string {
-	return message.rcpttoResponse
+// Getter for rcpttoRequestResponse field
+func (message *Message) RcpttoRequestResponse() [][]string {
+	return message.rcpttoRequestResponse
 }
 
 // Getter for rcptto field
@@ -118,6 +113,18 @@ func (message *Message) QuitSent() bool {
 // Otherwise returns false
 func (message *Message) isConsistent() bool {
 	return message.mailfrom && message.rcptto && message.data && message.msg
+}
+
+// Message RCPTTO successful response predicate. Returns true when at least one
+// successful RCPTTO response exists. Otherwise returns false
+func (message *Message) isIncludesSuccessfulRcpttoResponse(targetSuccessfulResponse string) bool {
+	for _, slice := range message.rcpttoRequestResponse {
+		if slice[1] == targetSuccessfulResponse {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Pointer to empty message

--- a/message_test.go
+++ b/message_test.go
@@ -54,19 +54,11 @@ func TestMessageMailfrom(t *testing.T) {
 	})
 }
 
-func TestMessageRcpttoRequest(t *testing.T) {
-	t.Run("getter for rcpttoRequest field", func(t *testing.T) {
-		message := &Message{rcpttoRequest: "some context"}
+func TestMessageRcpttoRequestResponse(t *testing.T) {
+	t.Run("getter for rcpttoRequestResponse field", func(t *testing.T) {
+		message := &Message{rcpttoRequestResponse: [][]string{[]string{"request", "response"}}}
 
-		assert.Equal(t, message.rcpttoRequest, message.RcpttoRequest())
-	})
-}
-
-func TestMessageRcpttoResponse(t *testing.T) {
-	t.Run("getter for rcpttoResponse field", func(t *testing.T) {
-		message := &Message{rcpttoResponse: "some context"}
-
-		assert.Equal(t, message.rcpttoResponse, message.RcpttoResponse())
+		assert.Equal(t, message.rcpttoRequestResponse, message.RcpttoRequestResponse())
 	})
 }
 
@@ -186,6 +178,20 @@ func TestMessageIsConsistent(t *testing.T) {
 		message := &Message{mailfrom: true, rcptto: true, data: true}
 
 		assert.False(t, message.isConsistent())
+	})
+}
+
+func TestMessageIsIncludesSuccessfulRcpttoResponse(t *testing.T) {
+	targetSuccessfulResponse := "response"
+
+	t.Run("when successful RCPTTO response exists", func(t *testing.T) {
+		message := &Message{rcpttoRequestResponse: [][]string{{"request", targetSuccessfulResponse}}}
+
+		assert.True(t, message.isIncludesSuccessfulRcpttoResponse(targetSuccessfulResponse))
+	})
+
+	t.Run("when successful RCPTTO response not exists", func(t *testing.T) {
+		assert.False(t, new(Message).isIncludesSuccessfulRcpttoResponse(targetSuccessfulResponse))
 	})
 }
 

--- a/script/publish.sh
+++ b/script/publish.sh
@@ -7,7 +7,7 @@ latest_tag() {
 
 publish_release() {
   echo "Triggering pkg.go.dev about new smtpmock release..."
-  curl -X POST "https://pkg.go.dev/fetch/github.com/mocktools/go-smtp-mock@$(latest_tag)"
+  curl -X POST "https://pkg.go.dev/fetch/github.com/mocktools/go-smtp-mock/v2@$(latest_tag)"
 }
 
 publish_release

--- a/smtpmock_test.go
+++ b/smtpmock_test.go
@@ -63,6 +63,8 @@ func TestNew(t *testing.T) {
 			LogToStdout:                   true,
 			LogServerActivity:             true,
 			IsCmdFailFast:                 true,
+			MultipleRcptto:                true,
+			MultipleMessageReceiving:      true,
 			MsgGreeting:                   "msgGreeting",
 			MsgInvalidCmd:                 "msgInvalidCmd",
 			MsgQuitCmd:                    "msgQuitCmd",
@@ -97,6 +99,8 @@ func TestNew(t *testing.T) {
 		assert.Equal(t, configAttr.PortNumber, configuration.portNumber)
 		assert.Equal(t, configAttr.LogToStdout, configuration.logToStdout)
 		assert.Equal(t, configAttr.IsCmdFailFast, configuration.isCmdFailFast)
+		assert.Equal(t, configAttr.MultipleRcptto, configuration.multipleRcptto)
+		assert.Equal(t, configAttr.MultipleMessageReceiving, configuration.multipleMessageReceiving)
 		assert.Equal(t, configAttr.LogServerActivity, configuration.logServerActivity)
 		assert.Equal(t, configAttr.MsgGreeting, configuration.msgGreeting)
 		assert.Equal(t, configAttr.MsgInvalidCmd, configuration.msgInvalidCmd)
@@ -139,7 +143,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("successful iteration with new server", func(t *testing.T) {
-		server := New(ConfigurationAttr{MultipleMessageReceiving: true})
+		server := New(ConfigurationAttr{MultipleRcptto: true, MultipleMessageReceiving: true})
 		configuration, messages := server.configuration, server.messages
 
 		assert.Empty(t, messages)
@@ -169,8 +173,8 @@ func TestNew(t *testing.T) {
 		assert.Equal(t, "MAIL FROM:<user@molo.com>", firstMessage.mailfromRequest)
 		assert.Equal(t, configuration.msgMailfromReceived, firstMessage.mailfromResponse)
 		assert.True(t, firstMessage.rcptto)
-		assert.Equal(t, "RCPT TO:<user1@olo.com>", firstMessage.rcpttoRequest)
-		assert.Equal(t, configuration.msgRcpttoReceived, firstMessage.rcpttoResponse)
+		assert.Equal(t, "RCPT TO:<user1@olo.com>", firstMessage.rcpttoRequestResponse[0][0])
+		assert.Equal(t, configuration.msgRcpttoReceived, firstMessage.rcpttoRequestResponse[0][1])
 		assert.True(t, firstMessage.data)
 		assert.Equal(t, "DATA", firstMessage.dataRequest)
 		assert.Equal(t, configuration.msgDataReceived, firstMessage.dataResponse)
@@ -186,8 +190,11 @@ func TestNew(t *testing.T) {
 		assert.Equal(t, "MAIL FROM:<user@molo.com>", secondMessage.mailfromRequest)
 		assert.Equal(t, configuration.msgMailfromReceived, secondMessage.mailfromResponse)
 		assert.True(t, secondMessage.rcptto)
-		assert.Equal(t, "RCPT TO:<user2@olo.com>", secondMessage.rcpttoRequest)
-		assert.Equal(t, configuration.msgRcpttoReceived, secondMessage.rcpttoResponse)
+		assert.Equal(t, "RCPT TO:<user2@olo.com>", secondMessage.rcpttoRequestResponse[0][0])
+		assert.Equal(t, configuration.msgRcpttoReceived, secondMessage.rcpttoRequestResponse[0][1])
+		assert.Equal(t, "RCPT TO:<user3@olo.com>", secondMessage.rcpttoRequestResponse[1][0])
+		assert.Equal(t, configuration.msgRcpttoReceived, secondMessage.rcpttoRequestResponse[1][1])
+
 		assert.True(t, secondMessage.data)
 		assert.Equal(t, "DATA", secondMessage.dataRequest)
 		assert.Equal(t, configuration.msgDataReceived, secondMessage.dataResponse)

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -23,24 +23,23 @@ func createConfiguration() *configuration {
 // Creates not empty message
 func createNotEmptyMessage() *Message {
 	return &Message{
-		heloRequest:      "a",
-		heloResponse:     "b",
-		mailfromRequest:  "c",
-		mailfromResponse: "d",
-		rcpttoRequest:    "a",
-		rcpttoResponse:   "b",
-		dataRequest:      "c",
-		dataResponse:     "d",
-		msgRequest:       "a",
-		msgResponse:      "b",
-		rsetRequest:      "a",
-		rsetResponse:     "b",
-		helo:             true,
-		mailfrom:         true,
-		rcptto:           true,
-		data:             true,
-		msg:              true,
-		rset:             true,
+		heloRequest:           "a",
+		heloResponse:          "b",
+		mailfromRequest:       "c",
+		mailfromResponse:      "d",
+		rcpttoRequestResponse: [][]string{[]string{"request", "response"}},
+		dataRequest:           "c",
+		dataResponse:          "d",
+		msgRequest:            "a",
+		msgResponse:           "b",
+		rsetRequest:           "a",
+		rsetResponse:          "b",
+		helo:                  true,
+		mailfrom:              true,
+		rcptto:                true,
+		data:                  true,
+		msg:                   true,
+		rset:                  true,
 	}
 }
 
@@ -65,7 +64,7 @@ func runFullFlow(client *smtp.Client) error {
 	var err error
 	var wc io.WriteCloser
 
-	sender, receiver1, receiver2 := "user@molo.com", "user1@olo.com", "user2@olo.com"
+	sender, receiver1, receiver2, receiver3 := "user@molo.com", "user1@olo.com", "user2@olo.com", "user3@olo.com"
 
 	if err = client.Mail(sender); err != nil {
 		return err
@@ -92,6 +91,9 @@ func runFullFlow(client *smtp.Client) error {
 		return err
 	}
 	if err = client.Rcpt(receiver2); err != nil {
+		return err
+	}
+	if err = client.Rcpt(receiver3); err != nil {
 		return err
 	}
 	wc, err = client.Data()


### PR DESCRIPTION
- [x] Added ability to use multiple `RCPT TO` commands during one SMTP session, following [RFC 2821](https://datatracker.ietf.org/doc/html/rfc2821#section-4.1.1.3) (section 4.1.1.3)
- [x] Updated `configuration`, `ConfigurationAttr`, tests
- [x] Updated `Message`, tests
- [x] Updated `handlerRcptto`, `handlerData`, tests
- [x] Updated `main#attrFromCommandLine`, tests
- [x] Updated go.mod version
- [x] Updated release publisher script
- [x] Updated CircleCI config
- [x] Updated project docs, changelog