### PR TITLE
Bugfix/Fix server race conditions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,10 @@ jobs:
           command: gotestsum --format standard-verbose -- -coverprofile=coverage_report ./...
 
       - run:
+          name: Checking for race conditions
+          command: go test -race ./...
+
+      - run:
           name: Creating coverage reports
           command: |
             mkdir -p /tmp/artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2022-11-14
+## [2.0.0] - 2022-11-16
 
 ### Added
 
@@ -10,15 +10,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `ConfigurationAttr#MultipleRcptto`, `configuration#multipleRcptto`, tests
 - Added `Message#rcpttoRequestResponse`, `Message#isIncludesSuccessfulRcpttoResponse()`, tests
 - Added `handlerRcptto#resolveMessageStatus()`, tests
+- Added `Message` public methods, tests
+- Added `Server` thread-safe getters/setters, tests
+
+### Fixed
+
+- Fixed race conditions with R/W lock in `Server`. Thanks [@benjamin-rood](https://github.com/benjamin-rood) for [report](https://github.com/mocktools/go-smtp-mock/issues/124) and [pull request](https://github.com/mocktools/go-smtp-mock/pull/125)
+- Fixed race conditions with R/W lock in `Message`
 
 ### Removed
 
 - Removed `Message#rcpttoRequest`, `Message#rcpttoResponse`
+- Removed `&Message` public methods
 
 ### Updated
 
 - Updated `handlerRcptto#clearMessage()`, `handlerRcptto#writeResult()`, `handlerData#clearMessage()`, tests
 - Updated Go reference trigger script
+- Updated `Server#Messages()`, returns slice of `Message` instead `&Message`
+- Updated CircleCI config, added checking for race conditions step
 - Updated project documentation
 
 ## [1.10.0] - 2022-09-09

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ func main() {
 
   // Server's port will be assigned dynamically after server.Start()
   // for case when portNumber wasn't specified
-  hostAddress, portNumber := "127.0.0.1", server.PortNumber
+  hostAddress, portNumber := "127.0.0.1", server.PortNumber()
 
   // Possible SMTP-client stuff for iteration with mock server
   address := fmt.Sprintf("%s:%d", hostAddress, portNumber)

--- a/message.go
+++ b/message.go
@@ -19,98 +19,106 @@ type Message struct {
 // message getters
 
 // Getter for heloRequest field
-func (message *Message) HeloRequest() string {
+func (message Message) HeloRequest() string {
 	return message.heloRequest
 }
 
 // Getter for heloResponse field
-func (message *Message) HeloResponse() string {
+func (message Message) HeloResponse() string {
 	return message.heloResponse
 }
 
 // Getter for helo field
-func (message *Message) Helo() bool {
+func (message Message) Helo() bool {
 	return message.helo
 }
 
 // Getter for mailfromRequest field
-func (message *Message) MailfromRequest() string {
+func (message Message) MailfromRequest() string {
 	return message.mailfromRequest
 }
 
 // Getter for mailfromResponse field
-func (message *Message) MailfromResponse() string {
+func (message Message) MailfromResponse() string {
 	return message.mailfromResponse
 }
 
 // Getter for mailfrom field
-func (message *Message) Mailfrom() bool {
+func (message Message) Mailfrom() bool {
 	return message.mailfrom
 }
 
 // Getter for rcpttoRequestResponse field
-func (message *Message) RcpttoRequestResponse() [][]string {
+func (message Message) RcpttoRequestResponse() [][]string {
 	return message.rcpttoRequestResponse
 }
 
 // Getter for rcptto field
-func (message *Message) Rcptto() bool {
+func (message Message) Rcptto() bool {
 	return message.rcptto
 }
 
 // Getter for dataRequest field
-func (message *Message) DataRequest() string {
+func (message Message) DataRequest() string {
 	return message.dataRequest
 }
 
 // Getter for dataResponse field
-func (message *Message) DataResponse() string {
+func (message Message) DataResponse() string {
 	return message.dataResponse
 }
 
 // Getter for data field
-func (message *Message) Data() bool {
+func (message Message) Data() bool {
 	return message.data
 }
 
 // Getter for msgRequest field
-func (message *Message) MsgRequest() string {
+func (message Message) MsgRequest() string {
 	return message.msgRequest
 }
 
 // Getter for msgResponse field
-func (message *Message) MsgResponse() string {
+func (message Message) MsgResponse() string {
 	return message.msgResponse
 }
 
 // Getter for msg field
-func (message *Message) Msg() bool {
+func (message Message) Msg() bool {
 	return message.msg
 }
 
 // Getter for rsetRequest field
-func (message *Message) RsetRequest() string {
+func (message Message) RsetRequest() string {
 	return message.rsetRequest
 }
 
 // Getter for rsetResponse field
-func (message *Message) RsetResponse() string {
+func (message Message) RsetResponse() string {
 	return message.rsetResponse
 }
 
 // Getter for rset field
-func (message *Message) Rset() bool {
+func (message Message) Rset() bool {
 	return message.rset
 }
 
 // Getter for quitSent field
-func (message *Message) QuitSent() bool {
+func (message Message) QuitSent() bool {
 	return message.quitSent
 }
 
-// Message consistency status predicate. Returns true for case when message struct is consistent.
-// It means that MAILFROM, RCPTTO, DATA commands and message context were successful.
-// Otherwise returns false
+// Getter for message consistency status predicate. Returns true
+// for case when message struct is consistent. It means that
+// MAILFROM, RCPTTO, DATA commands and message context
+// were successful. Otherwise returns false
+func (message Message) IsConsistent() bool {
+	return message.mailfrom && message.rcptto && message.data && message.msg
+}
+
+// Message pointer consistency status predicate. Returns true for case
+// when message struct is consistent. It means that MAILFROM, RCPTTO, DATA
+// commands and message context were successful. Otherwise returns false
 func (message *Message) isConsistent() bool {
 	return message.mailfrom && message.rcptto && message.data && message.msg
 }
@@ -132,7 +140,7 @@ var zeroMessage = &Message{}
 
 // Concurrent type that can be safely shared between goroutines
 type messages struct {
-	sync.RWMutex
+	sync.Mutex
 	items []*Message
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMessageHeloRequest(t *testing.T) {
 	t.Run("getter for heloRequest field", func(t *testing.T) {
-		message := &Message{heloRequest: "some context"}
+		message := Message{heloRequest: "some context"}
 
 		assert.Equal(t, message.heloRequest, message.HeloRequest())
 	})
@@ -16,7 +16,7 @@ func TestMessageHeloRequest(t *testing.T) {
 
 func TestMessageHeloResponse(t *testing.T) {
 	t.Run("getter for heloRequest field", func(t *testing.T) {
-		message := &Message{heloResponse: "some context"}
+		message := Message{heloResponse: "some context"}
 
 		assert.Equal(t, message.heloResponse, message.HeloResponse())
 	})
@@ -24,7 +24,7 @@ func TestMessageHeloResponse(t *testing.T) {
 
 func TestMessageHelo(t *testing.T) {
 	t.Run("getter for helo field", func(t *testing.T) {
-		message := &Message{helo: true}
+		message := Message{helo: true}
 
 		assert.Equal(t, message.helo, message.Helo())
 	})
@@ -32,7 +32,7 @@ func TestMessageHelo(t *testing.T) {
 
 func TestMessageMailfromRequest(t *testing.T) {
 	t.Run("getter for mailfromRequest field", func(t *testing.T) {
-		message := &Message{mailfromRequest: "some context"}
+		message := Message{mailfromRequest: "some context"}
 
 		assert.Equal(t, message.mailfromRequest, message.MailfromRequest())
 	})
@@ -40,7 +40,7 @@ func TestMessageMailfromRequest(t *testing.T) {
 
 func TestMessageMailfromResponse(t *testing.T) {
 	t.Run("getter for mailfromResponse field", func(t *testing.T) {
-		message := &Message{mailfromResponse: "some context"}
+		message := Message{mailfromResponse: "some context"}
 
 		assert.Equal(t, message.mailfromResponse, message.MailfromResponse())
 	})
@@ -48,7 +48,7 @@ func TestMessageMailfromResponse(t *testing.T) {
 
 func TestMessageMailfrom(t *testing.T) {
 	t.Run("getter for mailfrom field", func(t *testing.T) {
-		message := &Message{mailfrom: true}
+		message := Message{mailfrom: true}
 
 		assert.Equal(t, message.mailfrom, message.Mailfrom())
 	})
@@ -56,7 +56,7 @@ func TestMessageMailfrom(t *testing.T) {
 
 func TestMessageRcpttoRequestResponse(t *testing.T) {
 	t.Run("getter for rcpttoRequestResponse field", func(t *testing.T) {
-		message := &Message{rcpttoRequestResponse: [][]string{[]string{"request", "response"}}}
+		message := Message{rcpttoRequestResponse: [][]string{{"request", "response"}}}
 
 		assert.Equal(t, message.rcpttoRequestResponse, message.RcpttoRequestResponse())
 	})
@@ -64,7 +64,7 @@ func TestMessageRcpttoRequestResponse(t *testing.T) {
 
 func TestMessageRcptto(t *testing.T) {
 	t.Run("getter for rcptto field", func(t *testing.T) {
-		message := &Message{rcptto: true}
+		message := Message{rcptto: true}
 
 		assert.Equal(t, message.rcptto, message.Rcptto())
 	})
@@ -72,7 +72,7 @@ func TestMessageRcptto(t *testing.T) {
 
 func TestMessageDataRequest(t *testing.T) {
 	t.Run("getter for dataRequest field", func(t *testing.T) {
-		message := &Message{dataRequest: "some context"}
+		message := Message{dataRequest: "some context"}
 
 		assert.Equal(t, message.dataRequest, message.DataRequest())
 	})
@@ -80,7 +80,7 @@ func TestMessageDataRequest(t *testing.T) {
 
 func TestMessageDataResponse(t *testing.T) {
 	t.Run("getter for dataResponse field", func(t *testing.T) {
-		message := &Message{dataResponse: "some context"}
+		message := Message{dataResponse: "some context"}
 
 		assert.Equal(t, message.dataResponse, message.DataResponse())
 	})
@@ -88,7 +88,7 @@ func TestMessageDataResponse(t *testing.T) {
 
 func TestMessageData(t *testing.T) {
 	t.Run("getter for data field", func(t *testing.T) {
-		message := &Message{data: true}
+		message := Message{data: true}
 
 		assert.Equal(t, message.data, message.Data())
 	})
@@ -96,7 +96,7 @@ func TestMessageData(t *testing.T) {
 
 func TestMessageMsgRequest(t *testing.T) {
 	t.Run("getter for msgRequest field", func(t *testing.T) {
-		message := &Message{msgRequest: "some context"}
+		message := Message{msgRequest: "some context"}
 
 		assert.Equal(t, message.msgRequest, message.MsgRequest())
 	})
@@ -104,7 +104,7 @@ func TestMessageMsgRequest(t *testing.T) {
 
 func TestMessageMsgResponse(t *testing.T) {
 	t.Run("getter for msgRequest field", func(t *testing.T) {
-		message := &Message{msgResponse: "some context"}
+		message := Message{msgResponse: "some context"}
 
 		assert.Equal(t, message.msgResponse, message.MsgResponse())
 	})
@@ -112,7 +112,7 @@ func TestMessageMsgResponse(t *testing.T) {
 
 func TestMessageMsg(t *testing.T) {
 	t.Run("getter for msg field", func(t *testing.T) {
-		message := &Message{msg: true}
+		message := Message{msg: true}
 
 		assert.Equal(t, message.msg, message.Msg())
 	})
@@ -120,7 +120,7 @@ func TestMessageMsg(t *testing.T) {
 
 func TestMessageRsetRequest(t *testing.T) {
 	t.Run("getter for rsetRequest field", func(t *testing.T) {
-		message := &Message{rsetRequest: "some context"}
+		message := Message{rsetRequest: "some context"}
 
 		assert.Equal(t, message.rsetRequest, message.RsetRequest())
 	})
@@ -128,7 +128,7 @@ func TestMessageRsetRequest(t *testing.T) {
 
 func TestMessageRsetResponse(t *testing.T) {
 	t.Run("getter for rsetRequest field", func(t *testing.T) {
-		message := &Message{rsetResponse: "some context"}
+		message := Message{rsetResponse: "some context"}
 
 		assert.Equal(t, message.rsetResponse, message.RsetResponse())
 	})
@@ -136,7 +136,7 @@ func TestMessageRsetResponse(t *testing.T) {
 
 func TestMessageRset(t *testing.T) {
 	t.Run("getter for rset field", func(t *testing.T) {
-		message := &Message{rset: true}
+		message := Message{rset: true}
 
 		assert.Equal(t, message.rset, message.Rset())
 	})
@@ -144,13 +144,44 @@ func TestMessageRset(t *testing.T) {
 
 func TestMessageQuitSent(t *testing.T) {
 	t.Run("getter for quitSent field", func(t *testing.T) {
-		message := &Message{quitSent: true}
+		message := Message{quitSent: true}
 
 		assert.Equal(t, message.quitSent, message.QuitSent())
 	})
 }
 
 func TestMessageIsConsistent(t *testing.T) {
+	t.Run("when consistent", func(t *testing.T) {
+		message := &Message{mailfrom: true, rcptto: true, data: true, msg: true}
+
+		assert.True(t, message.IsConsistent())
+	})
+
+	t.Run("when not consistent MAILFROM", func(t *testing.T) {
+
+		assert.False(t, new(Message).IsConsistent())
+	})
+
+	t.Run("when not consistent RCPTTO", func(t *testing.T) {
+		message := &Message{mailfrom: true}
+
+		assert.False(t, message.IsConsistent())
+	})
+
+	t.Run("when not consistent DATA", func(t *testing.T) {
+		message := &Message{mailfrom: true, rcptto: true}
+
+		assert.False(t, message.IsConsistent())
+	})
+
+	t.Run("when not consistent MSG", func(t *testing.T) {
+		message := &Message{mailfrom: true, rcptto: true, data: true}
+
+		assert.False(t, message.IsConsistent())
+	})
+}
+
+func TestMessagePointerIsConsistent(t *testing.T) {
 	t.Run("when consistent", func(t *testing.T) {
 		message := &Message{mailfrom: true, rcptto: true, data: true, msg: true}
 

--- a/server.go
+++ b/server.go
@@ -24,9 +24,10 @@ type Server struct {
 	listener      net.Listener
 	wg            waitGroup
 	quit          chan interface{}
-	isStarted     bool
-	PortNumber    int
+	started       bool
+	portNumber    int
 	quitTimeout   chan interface{}
+	sync.Mutex
 }
 
 // SMTP mock server builder, creates new server
@@ -44,7 +45,7 @@ func newServer(configuration *configuration) *Server {
 // Start binds and runs SMTP mock server on specified port or random free port. Returns error for
 // case when server is active. Server port number will be assigned after successful start only
 func (server *Server) Start() (err error) {
-	if server.isStarted {
+	if server.isStarted() {
 		return errors.New(serverStartErrorMsg)
 	}
 
@@ -59,7 +60,9 @@ func (server *Server) Start() (err error) {
 	}
 
 	portNumber = listener.Addr().(*net.TCPAddr).Port
-	server.listener, server.isStarted, server.PortNumber = listener, true, portNumber
+	server.setListener(listener)
+	server.setPortNumber(portNumber)
+	server.start()
 	server.quit, server.quitTimeout = make(chan interface{}), make(chan interface{})
 	logger.infoActivity(fmt.Sprintf("%s: %d", serverStartMsg, portNumber))
 
@@ -91,21 +94,21 @@ func (server *Server) Start() (err error) {
 // Stop shutdowns server gracefully or force by timeout.
 // Returns error for case when server is not active
 func (server *Server) Stop() (err error) {
-	if server.isStarted {
+	if server.isStarted() {
 		close(server.quit)
 		server.listener.Close()
 
 		go func() {
 			server.wg.Wait()
 			server.quitTimeout <- true
-			server.isStarted = false
+			server.stop()
 			server.logger.infoActivity(serverStopMsg)
 		}()
 
 		select {
 		case <-server.quitTimeout:
 		case <-time.After(time.Duration(server.configuration.shutdownTimeout) * time.Second):
-			server.isStarted = false
+			server.stop()
 			server.logger.infoActivity(serverForceStopMsg)
 		}
 
@@ -116,9 +119,60 @@ func (server *Server) Stop() (err error) {
 }
 
 // Public interface to get access to server messages
-// Returns slice of message pointers
-func (server *Server) Messages() []*Message {
-	return server.messages.items
+// Returns slice with copy of messages
+func (server *Server) Messages() []Message {
+	server.Lock()
+	defer server.Unlock()
+	copiedMessages, messages := []Message{}, server.messages.items
+	for index := range messages {
+		copiedMessages = append(copiedMessages, *messages[index])
+	}
+
+	return copiedMessages
+}
+
+// Thread-safe getter of server port
+// Returns server.portNumber
+func (server *Server) PortNumber() int {
+	server.Lock()
+	defer server.Unlock()
+	return server.portNumber
+}
+
+// Thread-safe getter to check if server has been started
+// Returns server.started
+func (server *Server) isStarted() bool {
+	server.Lock()
+	defer server.Unlock()
+	return server.started
+}
+
+// Thread-safe setter of server.listener
+func (server *Server) setListener(listener net.Listener) {
+	server.Lock()
+	defer server.Unlock()
+	server.listener = listener
+}
+
+// Thread-safe setter of server.portNumber
+func (server *Server) setPortNumber(port int) {
+	server.Lock()
+	defer server.Unlock()
+	server.portNumber = port
+}
+
+// Thread-safe setter of started-flag to indicate server has been started
+func (server *Server) start() {
+	server.Lock()
+	defer server.Unlock()
+	server.started = true
+}
+
+// Thread-safe setter of started-flag to indicate server has been stopped
+func (server *Server) stop() {
+	server.Lock()
+	defer server.Unlock()
+	server.started = false
 }
 
 // Creates and assigns new message to server.messages

--- a/smtpmock_test.go
+++ b/smtpmock_test.go
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 		assert.NotNil(t, server.logger)
 		assert.NotNil(t, server.wg)
 		assert.Nil(t, server.quit)
-		assert.False(t, server.isStarted)
+		assert.False(t, server.isStarted())
 	})
 
 	t.Run("creates new server with custom configuration settings", func(t *testing.T) {
@@ -139,30 +139,30 @@ func TestNew(t *testing.T) {
 		assert.NotNil(t, server.logger)
 		assert.NotNil(t, server.wg)
 		assert.Nil(t, server.quit)
-		assert.False(t, server.isStarted)
+		assert.False(t, server.isStarted())
 	})
 
 	t.Run("successful iteration with new server", func(t *testing.T) {
 		server := New(ConfigurationAttr{MultipleRcptto: true, MultipleMessageReceiving: true})
-		configuration, messages := server.configuration, server.messages
+		configuration, messages := server.configuration, server.Messages()
 
 		assert.Empty(t, messages)
 		assert.NotNil(t, server.logger)
 		assert.NotNil(t, server.wg)
 		assert.Nil(t, server.quit)
-		assert.False(t, server.isStarted)
+		assert.False(t, server.isStarted())
 
 		assert.NoError(t, server.Start())
-		assert.True(t, server.isStarted)
-		_ = runSuccessfulSMTPSession(configuration.hostAddress, server.PortNumber, true)
+		assert.True(t, server.isStarted())
+		_ = runSuccessfulSMTPSession(configuration.hostAddress, server.PortNumber(), true)
 		_ = server.Stop()
 
-		assert.Equal(t, 2, len(messages.items))
+		assert.Equal(t, 2, len(server.Messages()))
 		assert.NotNil(t, server.quit)
-		assert.False(t, server.isStarted)
-		assert.Greater(t, server.PortNumber, 0)
+		assert.False(t, server.isStarted())
+		assert.Greater(t, server.PortNumber(), 0)
 
-		receivedMessages := messages.items
+		receivedMessages := server.Messages()
 		firstMessage, secondMessage := receivedMessages[0], receivedMessages[1]
 
 		assert.True(t, firstMessage.helo)
@@ -181,7 +181,7 @@ func TestNew(t *testing.T) {
 		assert.True(t, firstMessage.msg)
 		assert.Equal(t, string(messageBody("user@molo.com", "user1@olo.com"))+"\r\n", firstMessage.msgRequest)
 		assert.Equal(t, configuration.msgMsgReceived, firstMessage.msgResponse)
-		assert.True(t, firstMessage.isConsistent())
+		assert.True(t, firstMessage.IsConsistent())
 		assert.True(t, firstMessage.rset)
 		assert.Equal(t, "RSET", firstMessage.rsetRequest)
 		assert.Equal(t, configuration.msgRsetReceived, firstMessage.rsetResponse)
@@ -201,7 +201,7 @@ func TestNew(t *testing.T) {
 		assert.True(t, secondMessage.msg)
 		assert.Equal(t, string(messageBody("user@molo.com", "user2@olo.com"))+"\r\n", secondMessage.msgRequest)
 		assert.Equal(t, configuration.msgMsgReceived, secondMessage.msgResponse)
-		assert.True(t, secondMessage.isConsistent())
+		assert.True(t, secondMessage.IsConsistent())
 		assert.True(t, secondMessage.quitSent)
 	})
 }


### PR DESCRIPTION
This PR is a sequel of https://github.com/mocktools/go-smtp-mock/pull/125 by @benjamin-rood and fix for: https://github.com/mocktools/go-smtp-mock/issues/124

- [x] Resolved race conditions with R/W lock in `Server`
- [x] Resolved race conditions with R/W lock in `Message`
- [x] Updated CircleCI config to test race conditions

It will be released in a new major `smtpmock` release.