### PR TITLE
Bugfix/Autobuilds of smtpmock binary doesn't set version notes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,9 +12,9 @@ builds:
       - amd64
     ldflags:
       - -s -w
-      - -X github.com/mocktools/go-smtp-mock/cmd/version.Version={{.Version}}
-      - -X github.com/mocktools/go-smtp-mock/cmd/version.GitCommit={{.Commit}}
-      - -X github.com/mocktools/go-smtp-mock/cmd/version.BuildTime={{.Date}}
+      - -X github.com/mocktools/go-smtp-mock/v2/cmd/version.Version={{.Version}}
+      - -X github.com/mocktools/go-smtp-mock/v2/cmd/version.GitCommit={{.Commit}}
+      - -X github.com/mocktools/go-smtp-mock/v2/cmd/version.BuildTime={{.Date}}
 archives:
   - id: smtpmock-archive
     builds:

--- a/server_test.go
+++ b/server_test.go
@@ -182,7 +182,7 @@ func TestServerSetListener(t *testing.T) {
 		listener, _ := net.Listen("tcp", "localhost:2526")
 		server.setListener(listener)
 
-		assert.Equal(t, listener, server.listener) // TODO: do we need thread-safe getter for server.listener ?
+		assert.Equal(t, listener, server.listener)
 	})
 }
 


### PR DESCRIPTION
- [x] Upadted wrong link for `ldflags` in goreleaser config
- [x] Updated tests