### PR TITLE
Bugfix/Fix Messages race conditions

### DIFF
--- a/message.go
+++ b/message.go
@@ -145,16 +145,33 @@ var zeroMessage = &Message{}
 
 // Concurrent type that can be safely shared between goroutines
 type messages struct {
-	sync.Mutex
+	sync.RWMutex
 	items []*Message
 }
 
 // messages methods
 
-// Addes new message pointer into concurrent messages slice
+// Adds new message pointer into concurrent messages slice
 func (messages *messages) append(item *Message) {
 	messages.Lock()
 	defer messages.Unlock()
 
 	messages.items = append(messages.items, item)
+}
+
+// Returns a copy of all messages
+func (messages *messages) copy() []Message {
+	messages.RLock()
+	defer messages.RUnlock()
+
+	return messages.copyInternal()
+}
+
+// Copy without a lock
+func (messages *messages) copyInternal() []Message {
+	copiedMessages := []Message{}
+	for index := range messages.items {
+		copiedMessages = append(copiedMessages, *messages.items[index])
+	}
+	return copiedMessages
 }

--- a/message_test.go
+++ b/message_test.go
@@ -239,6 +239,20 @@ func TestMessagesAppend(t *testing.T) {
 		message, messages := new(Message), new(messages)
 		messages.append(message)
 
+		messages.RLock()
 		assert.Same(t, message, messages.items[0])
+		messages.RUnlock()
+	})
+}
+
+func TestMessagesCopy(t *testing.T) {
+	t.Run("copies messages", func(t *testing.T) {
+		message, messages := new(Message), new(messages)
+		message.heloRequest = "foobar"
+		messages.append(message)
+
+		copyMessages := messages.copy()
+		assert.Len(t, copyMessages, 1)
+		assert.Equal(t, *message, copyMessages[0])
 	})
 }

--- a/server_test.go
+++ b/server_test.go
@@ -33,7 +33,7 @@ func TestServerStart(t *testing.T) {
 
 		assert.NoError(t, server.Start())
 		_ = runSuccessfulSMTPSession(configuration.hostAddress, server.PortNumber(), false)
-		assert.NotEmpty(t, server.messages)
+		assert.NotNil(t, server.messages)
 		assert.NotNil(t, server.quit)
 		assert.NotNil(t, server.quitTimeout)
 		assert.True(t, server.isStarted())
@@ -49,7 +49,7 @@ func TestServerStart(t *testing.T) {
 
 		assert.NoError(t, server.Start())
 		_ = runSuccessfulSMTPSession(configuration.hostAddress, portNumber, false)
-		assert.NotEmpty(t, server.messages)
+		assert.NotNil(t, server.messages)
 		assert.NotNil(t, server.quit)
 		assert.NotNil(t, server.quitTimeout)
 		assert.True(t, server.isStarted())
@@ -139,7 +139,8 @@ func TestServerMessages(t *testing.T) {
 
 	t.Run("when there are messages on the server", func(t *testing.T) {
 		server := newServer(configuration)
-		server.newMessage()
+		message := new(Message)
+		server.messages.append(message)
 
 		assert.NotEmpty(t, server.Messages())
 	})
@@ -147,15 +148,20 @@ func TestServerMessages(t *testing.T) {
 	t.Run("message data are identical", func(t *testing.T) {
 		server := newServer(configuration)
 
+		server.messages.RLock()
 		assert.Empty(t, server.messages.items)
 		assert.Empty(t, server.Messages())
 		assert.NotSame(t, server.messages.items, server.Messages())
+		server.messages.RUnlock()
 
-		message := server.newMessage()
+		message := new(Message)
+		server.messages.append(message)
 
+		server.messages.RLock()
 		assert.Equal(t, []*Message{message}, server.messages.items)
 		assert.Equal(t, []Message{*message}, server.Messages())
 		assert.NotSame(t, server.messages.items, server.Messages())
+		server.messages.RUnlock()
 	})
 }
 
@@ -213,29 +219,21 @@ func TestServerStopFlag(t *testing.T) {
 	})
 }
 
-func TestServerNewMessage(t *testing.T) {
-	t.Run("pushes new message into server.messages, returns this message", func(t *testing.T) {
-		server := &Server{messages: new(messages)}
-		message, messages := server.newMessage(), server.messages.items
-
-		assert.NotEmpty(t, messages)
-		assert.Equal(t, message, messages[0])
-	})
-}
-
 func TestServerNewMessageWithHeloContext(t *testing.T) {
 	t.Run("pushes new message into server.messages with helo context from other message, returns this message", func(t *testing.T) {
 		server := &Server{messages: new(messages)}
-		message, heloRequest, heloResponse, helo := server.newMessage(), "heloRequest", "heloResponse", true
+		message, heloRequest, heloResponse, helo := new(Message), "heloRequest", "heloResponse", true
 		message.heloRequest, message.heloResponse, message.helo = heloRequest, heloResponse, helo
 		newMessage := server.newMessageWithHeloContext(message)
-		messages := server.messages.items
 
+		server.messages.RLock()
+		messages := server.messages.items
 		assert.Equal(t, heloRequest, newMessage.heloRequest)
 		assert.Equal(t, heloResponse, newMessage.heloResponse)
 		assert.Equal(t, helo, newMessage.helo)
-		assert.Equal(t, newMessage, messages[1])
-		assert.Equal(t, 2, len(messages))
+		assert.Equal(t, newMessage, messages[0])
+		assert.Equal(t, 1, len(messages))
+		server.messages.RUnlock()
 	})
 }
 


### PR DESCRIPTION
# PR Details

Fixes race condition between Messages and newMessage.

## Description

Reading of `server.messages` is protected by `server` mutex, but not writing to it. So there is a race condition.

This PR now changes that modifying `server.messages` uses messages lock (not the server lock). It also makes a change that message is appended to messages only after it has finished processing. This removes race conditions on changes to individual messages (otherwise you have another layer of race conditions, where one goroutine is modify a message while it is being handled and the other might be copying it from `server.messages`). By having a clear flow: message is created (by any goroutine) then worked on by one goroutine (i.e., while handling the message) and then passed through `server.messages` to another goroutine, there are no race conditions anymore.

This is a breaking change from previous behavior but I think it is semantically correct. Otherwise you might get half-processed message inside `server.messages` which might look like an invalid message but it simply has not yet finished processing.

This will also make it easier to do #119: because messages inside `server.messages` are there only after they have been processed it is easy to remove them from there if somebody wants that.

## Related Issue

See: https://github.com/mocktools/go-smtp-mock/issues/150

## Motivation and Context

It fixes the race condition.

## How Has This Been Tested

I ran 100 iterations (`-count 100`) of a test case which was otherwise regularly throwing a race condition error when running with `-race` detector.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/mocktools/go-smtp-mock/blob/master/CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] I have run `golangci-lint run` from the root directory to see all new and existing tests pass
- [x] I have run `go tool cover` to avoid test coverage degradation
