### PR TITLE
Bugfix/Invalid email address parsing for MAILFROM, RCPTTO commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2024-11-14
+
+### Fixed
+
+- Fixed issue with [invalid email address parsing](https://github.com/mocktools/go-smtp-mock/issues/135) for `MAIL FROM` and `RCPT TO` commands
+
 ## [2.3.1] - 2024-08-04
 
 ### Updated

--- a/consts.go
+++ b/consts.go
@@ -53,7 +53,7 @@ const (
 	// Regex patterns
 	availableCmdsRegexPattern  = `(?i)helo|ehlo|mail from:|rcpt to:|data|rset|noop|quit`
 	domainRegexPattern         = `(?i)([\p{L}0-9]+([\-.]{1}[\p{L}0-9]+)*\.\p{L}{2,63}|localhost)`
-	emailRegexPattern          = `(?i)<?((.+)@` + domainRegexPattern + `)>?`
+	emailRegexPattern          = `(?i)<?([\p{L}0-9][\p{L}0-9\-.]*[\p{L}0-9]+@` + domainRegexPattern + `)>?`
 	ipAddressRegexPattern      = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
 	addressLiteralRegexPattern = `|\[` + ipAddressRegexPattern + `\]`
 

--- a/handler_mailfrom_test.go
+++ b/handler_mailfrom_test.go
@@ -245,6 +245,24 @@ func TestHandlerMailfromMailfromEmail(t *testing.T) {
 
 		assert.Equal(t, emptyString, handler.mailfromEmail("MAIL FROM: "+invalidEmail))
 	})
+
+	t.Run("when request includes invalid email with multiple @ symbols", func(t *testing.T) {
+		invalidEmail := "a@a.com@b.com"
+
+		assert.Equal(t, emptyString, handler.mailfromEmail("MAIL FROM: "+invalidEmail))
+	})
+
+	t.Run("when request includes invalid email starting with dot", func(t *testing.T) {
+		invalidEmail := ".user@example.com"
+
+		assert.Equal(t, emptyString, handler.mailfromEmail("MAIL FROM: "+invalidEmail))
+	})
+
+	t.Run("when request includes invalid email ending with dot before @", func(t *testing.T) {
+		invalidEmail := "user.@example.com"
+
+		assert.Equal(t, emptyString, handler.mailfromEmail("MAIL FROM: "+invalidEmail))
+	})
 }
 
 func TestHandlerHeloIsBlacklistedEmail(t *testing.T) {

--- a/handler_rcptto_test.go
+++ b/handler_rcptto_test.go
@@ -345,6 +345,24 @@ func TestHandlerRcpttoRcpttoEmail(t *testing.T) {
 
 		assert.Equal(t, emptyString, handler.rcpttoEmail("RCPT TO: "+invalidEmail))
 	})
+
+	t.Run("when request includes invalid email address, wrong format", func(t *testing.T) {
+		invalidEmail := "a@a.com@b.com"
+
+		assert.Equal(t, emptyString, handler.rcpttoEmail("RCPT TO: "+invalidEmail))
+	})
+
+	t.Run("when request includes invalid email starting with dot", func(t *testing.T) {
+		invalidEmail := ".user@example.com"
+
+		assert.Equal(t, emptyString, handler.rcpttoEmail("RCPT TO: "+invalidEmail))
+	})
+
+	t.Run("when request includes invalid email ending with dot before @", func(t *testing.T) {
+		invalidEmail := "user.@example.com"
+
+		assert.Equal(t, emptyString, handler.rcpttoEmail("RCPT TO: "+invalidEmail))
+	})
 }
 
 func TestHandlerRcpttoIsBlacklistedEmail(t *testing.T) {


### PR DESCRIPTION
- [x] Updated `emailRegexPattern`
- [x] Updated `mailfrom`/`rcptto` handlers tests