### PR TITLE
bugfix/allow-plus-characters-in-email

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -53,7 +53,7 @@ const (
 	// Regex patterns
 	availableCmdsRegexPattern  = `(?i)helo|ehlo|mail from:|rcpt to:|data|rset|noop|quit`
 	domainRegexPattern         = `(?i)([\p{L}0-9]+([\-.]{1}[\p{L}0-9]+)*\.\p{L}{2,63}|localhost)`
-	emailRegexPattern          = `(?i)(?:[\p{L}\p{N}\s]*?<?)*?([a-zA-Z0-9][-a-zA-Z0-9.]*[a-zA-Z0-9]@` + domainRegexPattern + `)>*`
+	emailRegexPattern          = `(?i)(?:[\p{L}\p{N}\s]*?<?)*?([a-zA-Z0-9!#\$%&'\*\+\-/=\?\^_\x60\{\|\}~][-a-zA-Z0-9.!#\$%&'\*\+\-/=\?\^_\x60\{\|\}~]*[a-zA-Z0-9!#\$%&'\*\+\-/=\?\^_\x60\{\|\}~]@` + domainRegexPattern + `)>*`
 	ipAddressRegexPattern      = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
 	addressLiteralRegexPattern = `|\[` + ipAddressRegexPattern + `\]`
 


### PR DESCRIPTION
In the RFC, these characters are allowed in the local part. I was using this for testing and found that `+` didn't work, however that's a pretty commonly used character in email addresses. When I looked into the spec I found that there were many characters that are valid and so I added them to the regex alongside `+`.

# PR Details

This updates the email regex pattern to be more accepting of valid email addresses. Specifically allowing ones with `+`, but other RFC defined characters as well.

## Motivation and Context

The regex was incorrect according to the RFC, to allow more valid tests to execute against this server the email regex had to be adjusted.

## How Has This Been Tested

It was tested by executing a test against the server with the kind of email in question. You can also note that the only thing that's changed is the regex and you can see that it works with any Go regex tester tool and produces the desired results.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/mocktools/go-smtp-mock/blob/master/CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] I have run `golangci-lint run` from the root directory to see all new and existing tests pass
- [x] I have run `go tool cover` to avoid test coverage degradation