### PR TITLE
Feature/Support custom logger implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ smtpmock.ConfigurationAttr{
 package main
 
 import (
-  "bytes"
   "fmt"
   "net"
   "net/smtp"
@@ -288,43 +287,11 @@ import (
   smtpmock "github.com/mocktools/go-smtp-mock/v2"
 )
 
-// User-defined loggers can be defined by implementing the Logger interface.
-// For example, this custom logger writes to byte buffers instead of os.Stdout/Stderr.
-type customLogger struct {
-  out *bytes.Buffer
-  err *bytes.Buffer
-}
-
-func (l *customLogger) InfoActivity(m string) {
-  l.out.WriteString(m)
-}
-
-func (l *customLogger) Info(m string) {
-  l.out.WriteString(m)
-}
-
-func (l *customLogger) Warning(m string) {
-  l.out.WriteString(m)
-}
-
-func (l *customLogger) Error(m string) {
-  l.err.WriteString(m)
-}
-
 func main() {
   // You can pass empty smtpmock.ConfigurationAttr{}. It means that smtpmock will use default settings
   server := smtpmock.New(smtpmock.ConfigurationAttr{
     LogToStdout:       true,
     LogServerActivity: true,
-  })
-
-  // The default logger for the server can be substituted with a custom logging implementation.
-  // This can be useful in tests where the server logs need to be programatically examined.
-  outBuf := &bytes.Buffer{}
-  errBuf := &bytes.Buffer{}
-  server.WithLogger(&customLogger{
-    out: outBuf,
-    err: errBuf,
   })
 
   // To start server use Start() method
@@ -385,6 +352,73 @@ INFO: 2021/11/30 22:07:30.555722 SMTP response: 221 Closing connection
 INFO: 2021/11/30 22:07:30.555732 SMTP session finished
 WARNING: 2021/11/30 22:07:30.555801 SMTP mock server is in the shutdown mode and won't accept new connections
 INFO: 2021/11/30 22:07:30.555808 SMTP mock server was stopped successfully
+```
+
+#### Using a custom logger
+
+```go
+package main
+
+import (
+  "bytes"
+  "fmt"
+  "net"
+  "net/smtp"
+
+  smtpmock "github.com/mocktools/go-smtp-mock/v2"
+)
+
+// User-defined loggers can be defined by implementing the Logger interface.
+// For example, this custom logger writes to byte buffers instead of os.Stdout/Stderr.
+type customLogger struct {
+  out *bytes.Buffer
+  err *bytes.Buffer
+}
+
+func (l *customLogger) InfoActivity(m string) {
+  l.out.WriteString(m)
+}
+
+func (l *customLogger) Info(m string) {
+  l.out.WriteString(m)
+}
+
+func (l *customLogger) Warning(m string) {
+  l.out.WriteString(m)
+}
+
+func (l *customLogger) Error(m string) {
+  l.err.WriteString(m)
+}
+
+func main() {
+  // You can pass empty smtpmock.ConfigurationAttr{}. It means that smtpmock will use default settings
+  server := smtpmock.New(smtpmock.ConfigurationAttr{
+    LogToStdout:       true,
+    LogServerActivity: true,
+  })
+
+  // The default logger for the server can be substituted with a custom logging implementation.
+  // This can be useful in tests where the server logs need to be programatically examined.
+  outBuf := &bytes.Buffer{}
+  errBuf := &bytes.Buffer{}
+  server.WithLogger(&customLogger{
+    out: outBuf,
+    err: errBuf,
+  })
+
+  // To start server use Start() method
+  if err := server.Start(); err != nil {
+    fmt.Println(err)
+  }
+
+  // To stop the server use Stop() method. Please note, smtpmock uses graceful shutdown.
+  // It means that smtpmock will end all sessions after client responses or by session
+  // timeouts immediately.
+  if err := server.Stop(); err != nil {
+    fmt.Println(err)
+  }
+}
 ```
 
 ### Inside of Ruby ecosystem

--- a/logger.go
+++ b/logger.go
@@ -7,11 +7,11 @@ import (
 )
 
 // Logger interface
-type logger interface {
-	infoActivity(string)
-	info(string)
-	warning(string)
-	error(string)
+type Logger interface {
+	InfoActivity(string)
+	Info(string)
+	Warning(string)
+	Error(string)
 }
 
 // Custom logger that supports 3 different log levels (info, warning, error)
@@ -37,7 +37,7 @@ func newLogger(logToStdout, logServerActivity bool) *eventLogger {
 
 // Provides INFO log level for server activities. Writes to stdout for case when
 // logger.logToStdout and logger.logServerActivity are enabled, suppressed otherwise
-func (logger *eventLogger) infoActivity(message string) {
+func (logger *eventLogger) InfoActivity(message string) {
 	if logger.logToStdout && logger.logServerActivity {
 		if logger.eventInfo == nil {
 			logger.eventInfo = log.New(logger.stdout, infoLogLevel+": ", logger.flag)
@@ -49,7 +49,7 @@ func (logger *eventLogger) infoActivity(message string) {
 
 // Provides INFO log level. Writes to stdout for case when logger.logToStdout is enabled,
 // suppressed otherwise
-func (logger *eventLogger) info(message string) {
+func (logger *eventLogger) Info(message string) {
 	if logger.logToStdout {
 		if logger.eventInfo == nil {
 			logger.eventInfo = log.New(logger.stdout, infoLogLevel+": ", logger.flag)
@@ -61,7 +61,7 @@ func (logger *eventLogger) info(message string) {
 
 // Provides WARNING log level. Writes to stdout for case when logger.logToStdout is enabled,
 // suppressed otherwise
-func (logger *eventLogger) warning(message string) {
+func (logger *eventLogger) Warning(message string) {
 	if logger.logToStdout {
 		if logger.eventWarning == nil {
 			logger.eventWarning = log.New(logger.stdout, warningLogLevel+": ", logger.flag)
@@ -73,7 +73,7 @@ func (logger *eventLogger) warning(message string) {
 
 // Provides ERROR log level. Writes to stdout for case when logger.logToStdout is enabled,
 // suppressed otherwise
-func (logger *eventLogger) error(message string) {
+func (logger *eventLogger) Error(message string) {
 	if logger.logToStdout {
 		if logger.eventError == nil {
 			logger.eventError = log.New(logger.stderr, errorLogLevel+": ", logger.flag)

--- a/logger_test.go
+++ b/logger_test.go
@@ -41,12 +41,12 @@ func TestEventLoggerInfoActivity(t *testing.T) {
 		var buf bytes.Buffer
 		logger := newLogger(true, true)
 		logger.stdout = &buf
-		logger.infoActivity(logMessage) // initializes and memoizes INFO logger during first function calling
+		logger.InfoActivity(logMessage) // initializes and memoizes INFO logger during first function calling
 
 		assert.Regexp(t, loggerMessageRegex(infoLogLevel, logMessage), buf.String())
 		assert.NotNil(t, logger.eventInfo)
 		memoizedInfoLogger := logger.eventInfo
-		logger.infoActivity(logMessage)
+		logger.InfoActivity(logMessage)
 		assert.Same(t, memoizedInfoLogger, logger.eventInfo)
 	})
 
@@ -54,7 +54,7 @@ func TestEventLoggerInfoActivity(t *testing.T) {
 		var buf bytes.Buffer
 		logger := newLogger(false, true)
 		logger.stdout = &buf
-		logger.infoActivity(logMessage)
+		logger.InfoActivity(logMessage)
 
 		assert.Nil(t, logger.eventInfo)
 		assert.Empty(t, buf.String())
@@ -64,7 +64,7 @@ func TestEventLoggerInfoActivity(t *testing.T) {
 		var buf bytes.Buffer
 		logger := newLogger(true, false)
 		logger.stdout = &buf
-		logger.infoActivity(logMessage)
+		logger.InfoActivity(logMessage)
 
 		assert.Nil(t, logger.eventInfo)
 		assert.Empty(t, buf.String())
@@ -78,12 +78,12 @@ func TestEventLoggerInfo(t *testing.T) {
 		var buf bytes.Buffer
 		logger := newLogger(true, false)
 		logger.stdout = &buf
-		logger.info(logMessage) // initializes and memoizes INFO logger during first function calling
+		logger.Info(logMessage) // initializes and memoizes INFO logger during first function calling
 
 		assert.Regexp(t, loggerMessageRegex(infoLogLevel, logMessage), buf.String())
 		assert.NotNil(t, logger.eventInfo)
 		memoizedInfoLogger := logger.eventInfo
-		logger.info(logMessage)
+		logger.Info(logMessage)
 		assert.Same(t, memoizedInfoLogger, logger.eventInfo)
 	})
 
@@ -91,7 +91,7 @@ func TestEventLoggerInfo(t *testing.T) {
 		var buf bytes.Buffer
 		logger := newLogger(false, false)
 		logger.stdout = &buf
-		logger.info(logMessage)
+		logger.Info(logMessage)
 
 		assert.Nil(t, logger.eventInfo)
 		assert.Empty(t, buf.String())
@@ -105,12 +105,12 @@ func TestEventLoggerWarning(t *testing.T) {
 		var buf bytes.Buffer
 		logger := newLogger(true, false)
 		logger.stdout = &buf
-		logger.warning(logMessage) // initializes and memoizes WARNING logger during first function calling
+		logger.Warning(logMessage) // initializes and memoizes WARNING logger during first function calling
 
 		assert.Regexp(t, loggerMessageRegex(warningLogLevel, logMessage), buf.String())
 		assert.NotNil(t, logger.eventWarning)
 		memoizedWarningLogger := logger.eventWarning
-		logger.warning(logMessage)
+		logger.Warning(logMessage)
 		assert.Same(t, memoizedWarningLogger, logger.eventWarning)
 	})
 
@@ -118,7 +118,7 @@ func TestEventLoggerWarning(t *testing.T) {
 		var buf bytes.Buffer
 		logger := newLogger(false, false)
 		logger.stdout = &buf
-		logger.warning(logMessage)
+		logger.Warning(logMessage)
 
 		assert.Nil(t, logger.eventWarning)
 		assert.Empty(t, buf.String())
@@ -132,12 +132,12 @@ func TestEventLoggerError(t *testing.T) {
 		var buf bytes.Buffer
 		logger := newLogger(true, false)
 		logger.stderr = &buf
-		logger.error(logMessage) // initializes and memoizes ERROR logger during first function calling
+		logger.Error(logMessage) // initializes and memoizes ERROR logger during first function calling
 
 		assert.Regexp(t, loggerMessageRegex(errorLogLevel, logMessage), buf.String())
 		assert.NotNil(t, logger.eventError)
 		memoizedErrorLogger := logger.eventError
-		logger.error(logMessage)
+		logger.Error(logMessage)
 		assert.Same(t, memoizedErrorLogger, logger.eventError)
 	})
 
@@ -145,7 +145,7 @@ func TestEventLoggerError(t *testing.T) {
 		var buf bytes.Buffer
 		logger := newLogger(false, false)
 		logger.stderr = &buf
-		logger.error(logMessage)
+		logger.Error(logMessage)
 
 		assert.Nil(t, logger.eventError)
 		assert.Empty(t, buf.String())

--- a/server.go
+++ b/server.go
@@ -20,7 +20,7 @@ type waitGroup interface {
 type Server struct {
 	configuration *configuration
 	messages      *messages
-	logger        logger
+	logger        Logger
 	listener      net.Listener
 	wg            waitGroup
 	quit          chan interface{}
@@ -55,7 +55,7 @@ func (server *Server) Start() (err error) {
 	listener, err := net.Listen(networkProtocol, serverWithPortNumber(configuration.hostAddress, portNumber))
 	if err != nil {
 		errorMessage := fmt.Sprintf("%s: %d", serverErrorMsg, portNumber)
-		logger.error(errorMessage)
+		logger.Error(errorMessage)
 		return errors.New(errorMessage)
 	}
 
@@ -64,7 +64,7 @@ func (server *Server) Start() (err error) {
 	server.setPortNumber(portNumber)
 	server.start()
 	server.quit, server.quitTimeout = make(chan interface{}), make(chan interface{})
-	logger.infoActivity(fmt.Sprintf("%s: %d", serverStartMsg, portNumber))
+	logger.InfoActivity(fmt.Sprintf("%s: %d", serverStartMsg, portNumber))
 
 	server.addToWaitGroup()
 	go func() {
@@ -73,7 +73,7 @@ func (server *Server) Start() (err error) {
 			connection, err := server.listener.Accept()
 			if err != nil {
 				if _, ok := <-server.quit; !ok {
-					logger.warning(serverNotAcceptNewConnectionsMsg)
+					logger.Warning(serverNotAcceptNewConnectionsMsg)
 				}
 				return
 			}
@@ -84,7 +84,7 @@ func (server *Server) Start() (err error) {
 				server.removeFromWaitGroup()
 			}()
 
-			logger.infoActivity(sessionStartMsg)
+			logger.InfoActivity(sessionStartMsg)
 		}
 	}()
 
@@ -102,14 +102,14 @@ func (server *Server) Stop() (err error) {
 			server.wg.Wait()
 			server.quitTimeout <- true
 			server.stop()
-			server.logger.infoActivity(serverStopMsg)
+			server.logger.InfoActivity(serverStopMsg)
 		}()
 
 		select {
 		case <-server.quitTimeout:
 		case <-time.After(time.Duration(server.configuration.shutdownTimeout) * time.Second):
 			server.stop()
-			server.logger.infoActivity(serverForceStopMsg)
+			server.logger.InfoActivity(serverForceStopMsg)
 		}
 
 		return

--- a/server.go
+++ b/server.go
@@ -40,6 +40,13 @@ func newServer(configuration *configuration) *Server {
 	}
 }
 
+// WithLogger installs the provided logger implementation to the server.
+// This allows for custom logging behavior, such as writing to a file or using a different logging library.
+func (server *Server) WithLogger(logger Logger) *Server {
+	server.logger = logger
+	return server
+}
+
 // server methods
 
 // Start binds and runs SMTP mock server on specified port or random free port. Returns error for

--- a/server_test.go
+++ b/server_test.go
@@ -25,6 +25,21 @@ func TestNewServer(t *testing.T) {
 		assert.False(t, server.isStarted())
 		assert.Equal(t, 0, server.PortNumber())
 	})
+
+	t.Run("creates new server with custom logger", func(t *testing.T) {
+		configuration := createConfiguration()
+		logger := new(loggerMock)
+		server := newServer(configuration).WithLogger(logger)
+
+		assert.Same(t, configuration, server.configuration)
+		assert.Equal(t, new(messages), server.messages)
+		assert.Equal(t, logger, server.logger)
+		assert.Nil(t, server.listener)
+		assert.NotNil(t, server.wg)
+		assert.Nil(t, server.quit)
+		assert.False(t, server.isStarted())
+		assert.Equal(t, 0, server.PortNumber())
+	})
 }
 
 func TestServerStart(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -73,7 +73,7 @@ func TestServerStart(t *testing.T) {
 		portNumber := listener.Addr().(*net.TCPAddr).Port
 		errorMessage := fmt.Sprintf("%s: %d", serverErrorMsg, portNumber)
 		configuration.portNumber, server.logger = portNumber, logger
-		logger.On("error", errorMessage).Once().Return(nil)
+		logger.On("Error", errorMessage).Once().Return(nil)
 
 		assert.EqualError(t, server.Start(), errorMessage)
 		assert.False(t, server.isStarted())
@@ -96,7 +96,7 @@ func TestServerStop(t *testing.T) {
 		}
 		listener.On("Close").Once().Return(nil)
 		waitGroup.On("Wait").Once().Return(nil)
-		logger.On("infoActivity", serverStopMsg).Once().Return(nil)
+		logger.On("InfoActivity", serverStopMsg).Once().Return(nil)
 
 		assert.NoError(t, server.Stop())
 		assert.False(t, server.isStarted())
@@ -116,7 +116,7 @@ func TestServerStop(t *testing.T) {
 		}
 		listener.On("Close").Once().Return(nil)
 		waitGroup.On("Wait").Once().Return(nil)
-		logger.On("infoActivity", serverForceStopMsg).Once().Return(nil)
+		logger.On("InfoActivity", serverForceStopMsg).Once().Return(nil)
 
 		assert.NoError(t, server.Stop())
 		assert.False(t, server.isStarted())

--- a/session.go
+++ b/session.go
@@ -51,11 +51,11 @@ type session struct {
 	bufin      bufin
 	bufout     bufout
 	err        error
-	logger     logger
+	logger     Logger
 }
 
 // SMTP session builder. Creates new session
-func newSession(connection net.Conn, logger logger) *session {
+func newSession(connection net.Conn, logger Logger) *session {
 	return &session{
 		connection: connection,
 		address:    connection.RemoteAddr().String(),
@@ -90,7 +90,7 @@ func (session *session) setTimeout(timeout int) {
 
 	if err != nil {
 		session.err = err
-		session.logger.error(err.Error())
+		session.logger.Error(err.Error())
 	}
 }
 
@@ -101,7 +101,7 @@ func (session *session) discardBufin() {
 
 	if err != nil {
 		session.err = err
-		session.logger.error(err.Error())
+		session.logger.Error(err.Error())
 	}
 }
 
@@ -111,12 +111,12 @@ func (session *session) readRequest() (string, error) {
 	request, err := session.bufin.ReadString('\n')
 	if err == nil {
 		trimmedRequest := strings.TrimSpace(request)
-		session.logger.infoActivity(sessionRequestMsg + trimmedRequest)
+		session.logger.InfoActivity(sessionRequestMsg + trimmedRequest)
 		return trimmedRequest, err
 	}
 
 	session.err = err
-	session.logger.error(err.Error())
+	session.logger.Error(err.Error())
 	return emptyString, err
 }
 
@@ -126,12 +126,12 @@ func (session *session) readBytes() ([]byte, error) {
 	var request []byte
 	request, err := session.bufin.ReadBytes('\n')
 	if err == nil {
-		session.logger.infoActivity(sessionRequestMsg + sessionBinaryDataMsg)
+		session.logger.InfoActivity(sessionRequestMsg + sessionBinaryDataMsg)
 		return request, err
 	}
 
 	session.err = err
-	session.logger.error(err.Error())
+	session.logger.Error(err.Error())
 	return request, err
 }
 
@@ -142,7 +142,7 @@ func (session *session) responseDelay(delay int) int {
 		return delay
 	}
 
-	session.logger.infoActivity(fmt.Sprintf("%s: %d sec", sessionResponseDelayMsg, delay))
+	session.logger.InfoActivity(fmt.Sprintf("%s: %d sec", sessionResponseDelayMsg, delay))
 	return timeSleep(delay)
 }
 
@@ -152,17 +152,17 @@ func (session *session) writeResponse(response string, responseDelay int) {
 	session.responseDelay(responseDelay)
 	bufout := session.bufout
 	if _, err := bufout.WriteString(response + "\r\n"); err != nil {
-		session.logger.warning(err.Error())
+		session.logger.Warning(err.Error())
 	}
 	bufout.Flush()
-	session.logger.infoActivity(sessionResponseMsg + response)
+	session.logger.InfoActivity(sessionResponseMsg + response)
 }
 
 // Finishes SMTP session. When error case happened triggers logger with warning level
 func (session *session) finish() {
 	if err := session.connection.Close(); err != nil {
-		session.logger.warning(err.Error())
+		session.logger.Warning(err.Error())
 	}
 
-	session.logger.infoActivity(sessionEndMsg)
+	session.logger.InfoActivity(sessionEndMsg)
 }

--- a/session_test.go
+++ b/session_test.go
@@ -71,7 +71,7 @@ func TestSessionSetTimeout(t *testing.T) {
 		errorMessage, connection, logger := "some connection error", netConnectionMock{}, new(loggerMock)
 		err := errors.New(errorMessage)
 		connection.On("SetDeadline", timeNow().Add(time.Duration(timeout)*time.Second)).Once().Return(err)
-		logger.On("error", errorMessage).Once().Return(nil)
+		logger.On("Error", errorMessage).Once().Return(nil)
 		session := &session{connection: connection, logger: logger}
 		session.setTimeout(timeout)
 
@@ -94,7 +94,7 @@ func TestSessionDiscardBufin(t *testing.T) {
 		session, err := &session{bufin: bufin, logger: logger}, errors.New(errorMessage)
 		bufin.On("Buffered").Once().Return(42)
 		bufin.On("Discard", 42).Once().Return(42, err)
-		logger.On("error", errorMessage).Once().Return(nil)
+		logger.On("Error", errorMessage).Once().Return(nil)
 		session.discardBufin()
 
 		assert.Error(t, session.err)
@@ -125,7 +125,7 @@ func TestSessionReadRequest(t *testing.T) {
 		binaryData := strings.NewReader(stringContext)
 		bufin, logger := bufio.NewReader(binaryData), new(loggerMock)
 		session := &session{bufin: bufin, logger: logger}
-		logger.On("infoActivity", sessionRequestMsg+capturedStringContext).Once().Return(nil)
+		logger.On("InfoActivity", sessionRequestMsg+capturedStringContext).Once().Return(nil)
 		request, err := session.readRequest()
 
 		assert.Equal(t, capturedStringContext, request)
@@ -138,7 +138,7 @@ func TestSessionReadRequest(t *testing.T) {
 		errorMessage, bufin, logger := "read error", new(bufioReaderMock), new(loggerMock)
 		err := errors.New(errorMessage)
 		bufin.On("ReadString", delim).Once().Return(emptyString, err)
-		logger.On("error", errorMessage).Once().Return(nil)
+		logger.On("Error", errorMessage).Once().Return(nil)
 		session := &session{bufin: bufin, logger: logger}
 		request, err := session.readRequest()
 
@@ -153,7 +153,7 @@ func TestSessionReadBytes(t *testing.T) {
 		str := "stringContext\n"
 		bufin, logger := bufio.NewReader(strings.NewReader(str)), new(loggerMock)
 		session := &session{bufin: bufin, logger: logger}
-		logger.On("infoActivity", sessionRequestMsg+sessionBinaryDataMsg).Once().Return(nil)
+		logger.On("InfoActivity", sessionRequestMsg+sessionBinaryDataMsg).Once().Return(nil)
 		request, err := session.readBytes()
 
 		assert.Equal(t, []uint8(str), request)
@@ -166,7 +166,7 @@ func TestSessionReadBytes(t *testing.T) {
 		errorMessage, bufin, logger := "read error", new(bufioReaderMock), new(loggerMock)
 		err := errors.New(errorMessage)
 		bufin.On("ReadBytes", delim).Once().Return([]byte{}, err)
-		logger.On("error", errorMessage).Once().Return(nil)
+		logger.On("Error", errorMessage).Once().Return(nil)
 		session := &session{bufin: bufin, logger: logger}
 		request, err := session.readBytes()
 
@@ -184,7 +184,7 @@ func TestSessionResponseDelay(t *testing.T) {
 	t.Run("when custom session response delay", func(t *testing.T) {
 		timeSleep = func(delay int) int { return delay }
 		delay, logger := 42, new(loggerMock)
-		logger.On("infoActivity", fmt.Sprintf("%s: %d sec", sessionResponseDelayMsg, delay)).Once().Return(nil)
+		logger.On("InfoActivity", fmt.Sprintf("%s: %d sec", sessionResponseDelayMsg, delay)).Once().Return(nil)
 		session := &session{logger: logger}
 
 		assert.Equal(t, delay, session.responseDelay(delay))
@@ -196,7 +196,7 @@ func TestSessionWriteResponse(t *testing.T) {
 		response := "some response"
 		binaryData := bytes.NewBufferString("")
 		bufout, logger := bufio.NewWriter(binaryData), new(loggerMock)
-		logger.On("infoActivity", sessionResponseMsg+response).Once().Return(nil)
+		logger.On("InfoActivity", sessionResponseMsg+response).Once().Return(nil)
 		session := &session{bufout: bufout, logger: logger}
 		session.writeResponse(response, defaultSessionResponseDelay)
 
@@ -209,8 +209,8 @@ func TestSessionWriteResponse(t *testing.T) {
 		response, delay := "some response", 42
 		binaryData := bytes.NewBufferString("")
 		bufout, logger := bufio.NewWriter(binaryData), new(loggerMock)
-		logger.On("infoActivity", sessionResponseMsg+response).Once().Return(nil)
-		logger.On("infoActivity", fmt.Sprintf("%s: %d sec", sessionResponseDelayMsg, delay)).Once().Return(nil)
+		logger.On("InfoActivity", sessionResponseMsg+response).Once().Return(nil)
+		logger.On("InfoActivity", fmt.Sprintf("%s: %d sec", sessionResponseDelayMsg, delay)).Once().Return(nil)
 		session := &session{bufout: bufout, logger: logger}
 		session.writeResponse(response, delay)
 
@@ -223,8 +223,8 @@ func TestSessionWriteResponse(t *testing.T) {
 		err := errors.New(errorMessage)
 		bufout.On("WriteString", response+"\r\n").Once().Return(0, err)
 		bufout.On("Flush").Once().Return(err)
-		logger.On("warning", errorMessage).Once().Return(nil)
-		logger.On("infoActivity", sessionResponseMsg+response).Once().Return(nil)
+		logger.On("Warning", errorMessage).Once().Return(nil)
+		logger.On("InfoActivity", sessionResponseMsg+response).Once().Return(nil)
 		session := &session{bufout: bufout, logger: logger}
 		session.writeResponse(response, defaultSessionResponseDelay)
 
@@ -236,7 +236,7 @@ func TestSessionFinish(t *testing.T) {
 	t.Run("closes session connection without error", func(t *testing.T) {
 		connection, logger := netConnectionMock{}, new(loggerMock)
 		connection.On("Close").Once().Return(nil)
-		logger.On("infoActivity", sessionEndMsg).Once().Return(nil)
+		logger.On("InfoActivity", sessionEndMsg).Once().Return(nil)
 		session := &session{connection: connection, logger: logger}
 		session.finish()
 
@@ -247,8 +247,8 @@ func TestSessionFinish(t *testing.T) {
 		errorMessage := "connection error"
 		connection, logger, err := netConnectionMock{}, new(loggerMock), errors.New(errorMessage)
 		connection.On("Close").Once().Return(err)
-		logger.On("warning", errorMessage).Once().Return(nil)
-		logger.On("infoActivity", sessionEndMsg).Once().Return(nil)
+		logger.On("Warning", errorMessage).Once().Return(nil)
+		logger.On("InfoActivity", sessionEndMsg).Once().Return(nil)
 		session := &session{connection: connection, logger: logger}
 		session.finish()
 

--- a/test_mocks_test.go
+++ b/test_mocks_test.go
@@ -114,19 +114,19 @@ type loggerMock struct {
 	mock.Mock
 }
 
-func (logger *loggerMock) infoActivity(message string) {
+func (logger *loggerMock) InfoActivity(message string) {
 	logger.Called(message)
 }
 
-func (logger *loggerMock) info(message string) {
+func (logger *loggerMock) Info(message string) {
 	logger.Called(message)
 }
 
-func (logger *loggerMock) warning(message string) {
+func (logger *loggerMock) Warning(message string) {
 	logger.Called(message)
 }
 
-func (logger *loggerMock) error(message string) {
+func (logger *loggerMock) Error(message string) {
 	logger.Called(message)
 }
 


### PR DESCRIPTION
# PR Details

This PR adds support for custom logger implementations for the server.

## Description

The `logger` interface is now exported as `Logger` along with its interface methods. All code points using the logger have also been updated to use the now-exported interface.

A new `WithLogger` setter is provided to `Server`, allowing users to overwrite the default logger created by `newServer`.

The documentation in README has been updated with a usage example.

## Related Issue

#171 

## Motivation and Context

By exposing the logger interface, it becomes possible to redirect log output, which is useful in testing scenarios where examining log output is required.

## How Has This Been Tested

Test code has been added to test the added `WithLogger` method.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/mocktools/go-smtp-mock/blob/master/CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] I have run `golangci-lint run` from the root directory to see all new and existing tests pass
- [x] I have run `go tool cover` to avoid test coverage degradation